### PR TITLE
feat: add member page profile

### DIFF
--- a/cypress/fixtures/members.js
+++ b/cypress/fixtures/members.js
@@ -1,6 +1,20 @@
 export const MEMBERS = {
-  ANNA: { id: 'anna-id', name: 'anna', email: 'anna@email.com' },
-  BOB: { id: 'bob-id', name: 'bob', email: 'bob@email.com' },
+  ANNA: {
+    id: 'ecafbd2a-5642-31fb-ae93-0242ac130002',
+    name: 'anna',
+    email: 'anna@email.com',
+    createdAt: '2021-04-13 14:56:34.749946',
+    extra: {
+      lang: 'fr',
+    },
+  },
+  BOB: {
+    id: 'ecafbd2a-5688-11eb-fb52-3212ac130002',
+    name: 'bob',
+    email: 'bob@email.com',
+    createdAt: '2021-04-13 14:56:34.749946',
+    extra: { lang: 'en' },
+  },
 };
 
 export const CURRENT_USER = MEMBERS.ANNA;

--- a/cypress/integration/authentication.spec.js
+++ b/cypress/integration/authentication.spec.js
@@ -9,6 +9,7 @@ import {
   HEADER_APP_BAR_ID,
   HEADER_USER_ID,
   ITEM_MAIN_CLASS,
+  REDIRECTION_CONTENT_ID,
   USER_MENU_SIGN_OUT_OPTION_ID,
 } from '../../src/config/selectors';
 import { SAMPLE_ITEMS } from '../fixtures/items';
@@ -16,7 +17,6 @@ import { CURRENT_USER } from '../fixtures/members';
 import {
   REQUEST_FAILURE_LOADING_TIME,
   PAGE_LOAD_WAITING_PAUSE,
-  REDIRECTION_CONTENT,
   REDIRECTION_TIME,
 } from '../support/constants';
 import { REDIRECT_URL_LOCAL_STORAGE_KEY } from '../../src/config/constants';
@@ -33,7 +33,7 @@ describe('Authentication', () => {
         'equal',
         HOME_PATH,
       );
-      cy.get('html').should('contain', REDIRECTION_CONTENT);
+      cy.get(`#${REDIRECTION_CONTENT_ID}`).should('exist');
     });
     it('Shared Items', () => {
       cy.visit(SHARED_ITEMS_PATH);
@@ -42,7 +42,7 @@ describe('Authentication', () => {
         'equal',
         SHARED_ITEMS_PATH,
       );
-      cy.get('html').should('contain', REDIRECTION_CONTENT);
+      cy.get(`#${REDIRECTION_CONTENT_ID}`).should('exist');
     });
   });
 
@@ -53,11 +53,13 @@ describe('Authentication', () => {
 
     it('Signing Off redirect to sign in route', () => {
       cy.visit(HOME_PATH);
-      // user name in header
       cy.get(`#${HEADER_USER_ID}`).click();
       cy.get(`#${USER_MENU_SIGN_OUT_OPTION_ID}`).click();
       cy.wait(REQUEST_FAILURE_LOADING_TIME);
-      cy.get('html').should('contain', REDIRECTION_CONTENT);
+
+      // should refetch current member just after signing out
+      // this current member will be unauthorized and thus redirect
+      cy.wait(['@signOut', '@getCurrentMember']);
     });
 
     describe('Load page correctly', () => {

--- a/cypress/integration/memberProfile.spec.js
+++ b/cypress/integration/memberProfile.spec.js
@@ -1,0 +1,57 @@
+import { MEMBER_PROFILE_PATH } from '../../src/config/paths';
+import { langs } from '../../src/config/i18n';
+import {
+  MEMBER_PROFILE_MEMBER_ID_ID,
+  MEMBER_PROFILE_MEMBER_NAME_ID,
+  MEMBER_PROFILE_EMAIL_ID,
+  MEMBER_PROFILE_LANGUAGE_SWITCH_ID,
+  MEMBER_PROFILE_INSCRIPTION_DATE_ID,
+  MEMBER_PROFILE_MEMBER_ID_COPY_BUTTON_ID,
+} from '../../src/config/selectors';
+import { CURRENT_USER } from '../fixtures/members';
+import { formatDate } from '../../src/utils/date';
+
+describe('Member Profile', () => {
+  beforeEach(() => {
+    cy.setUpApi();
+    cy.visit(MEMBER_PROFILE_PATH);
+  });
+
+  it('Layout', () => {
+    const { id, name, email, extra, createdAt } = CURRENT_USER;
+    cy.get(`#${MEMBER_PROFILE_MEMBER_ID_ID}`).should('contain', id);
+    cy.get(`#${MEMBER_PROFILE_MEMBER_NAME_ID}`).should('contain', name);
+    cy.get(`#${MEMBER_PROFILE_EMAIL_ID}`).should('contain', email);
+    cy.get(`#${MEMBER_PROFILE_INSCRIPTION_DATE_ID}`).should(
+      'contain',
+      formatDate(createdAt),
+    );
+    cy.get(`#${MEMBER_PROFILE_LANGUAGE_SWITCH_ID}`).should(
+      'contain',
+      langs[extra.lang],
+    );
+  });
+
+  it('Changing Language edits user', () => {
+    const { id } = CURRENT_USER;
+
+    cy.get(`#${MEMBER_PROFILE_LANGUAGE_SWITCH_ID}`).select('en');
+
+    cy.wait('@editMember').then(({ request: { body, url } }) => {
+      expect(url).to.contain(id);
+      expect(body?.extra?.lang).to.equal('en');
+    });
+  });
+
+  it('Copy member ID to clipboard', () => {
+    const { id } = CURRENT_USER;
+
+    cy.get(`#${MEMBER_PROFILE_MEMBER_ID_COPY_BUTTON_ID}`).click();
+
+    cy.window().then((win) => {
+      win.navigator.clipboard.readText().then((text) => {
+        expect(text).to.equal(id);
+      });
+    });
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -27,6 +27,7 @@ module.exports = (on, config) => {
         root: '#root',
       },
       API_HOST: process.env.REACT_APP_API_HOST,
+      AUTHENTICATION_HOST: process.env.REACT_APP_AUTHENTICATION_HOST,
       S3_FILES_HOST:
         // calls to this host are mocked, but still should be reachable
         // set an s3 host or fake it by using the same host as the api's

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,6 +33,8 @@ import {
   mockGetTags,
   mockPostItemTag,
   mockPutItemLogin,
+  mockEditMember,
+  mockGetSharedItems,
 } from './server';
 import './commands/item';
 import './commands/navigation';
@@ -62,11 +64,14 @@ Cypress.Commands.add(
     postItemTagError = false,
     postItemLoginError = false,
     putItemLoginError = false,
+    editMemberError = false,
   } = {}) => {
     const cachedItems = JSON.parse(JSON.stringify(items));
     const cachedMembers = JSON.parse(JSON.stringify(members));
 
     mockGetOwnItems(cachedItems);
+
+    mockGetSharedItems({ items: cachedItems, member: currentMember });
 
     mockPostItem(cachedItems, postItemError);
 
@@ -118,6 +123,8 @@ Cypress.Commands.add(
     mockGetItemTags(items);
 
     mockPostItemTag(items, postItemTagError);
+
+    mockEditMember(members, editMemberError);
   },
 );
 

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -3,7 +3,7 @@ export const EDIT_ITEM_PAUSE = 1000;
 export const ITEM_LOGIN_PAUSE = 1000;
 export const NAVIGATE_PAUSE = 500;
 export const PAGE_LOAD_WAITING_PAUSE = 3000;
-export const REQUEST_FAILURE_LOADING_TIME = 3000;
+export const REQUEST_FAILURE_LOADING_TIME = 1500;
 export const TREE_VIEW_PAUSE = 2000;
 
 export const REDIRECTION_CONTENT = 'hello';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@graasp/query-client": "git://github.com/graasp/graasp-query-client.git",
-    "@graasp/ui": "git://github.com/graasp/graasp-ui.git",
+    "@graasp/ui": "git://github.com/graasp/graasp-ui.git#master",
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,40 +6,44 @@ import {
   SHARED_ITEMS_PATH,
   buildItemPath,
   REDIRECT_PATH,
+  MEMBER_PROFILE_PATH,
 } from '../config/paths';
 import Home from './main/Home';
 import ItemScreen from './main/ItemScreen';
 import SharedItems from './SharedItems';
-import Main from './main/Main';
 import Authorization from './common/Authorization';
 import ModalProviders from './context/ModalProviders';
 import ItemLoginAuthorization from './common/ItemLoginAuthorization';
 import Redirect from './main/Redirect';
+import MemberProfileScreen from './member/MemberProfileScreen';
 
 const App = () => (
   <ModalProviders>
     <Router>
-      <Main>
-        <Switch>
-          <Route path={HOME_PATH} exact component={Authorization()(Home)} />
-          <Route
-            path={SHARED_ITEMS_PATH}
-            exact
-            component={Authorization()(SharedItems)}
-          />
-          <Route
-            path={buildItemPath()}
-            component={ItemLoginAuthorization()(ItemScreen)}
-          />
-          <Route path={ITEMS_PATH} exact component={Authorization()(Home)} />
-          <Route
-            path={REDIRECT_PATH}
-            exact
-            component={Authorization()(Redirect)}
-          />
-          <Redirect to={HOME_PATH} />
-        </Switch>
-      </Main>
+      <Switch>
+        <Route path={HOME_PATH} exact component={Authorization()(Home)} />
+        <Route
+          path={SHARED_ITEMS_PATH}
+          exact
+          component={Authorization()(SharedItems)}
+        />
+        <Route
+          path={buildItemPath()}
+          component={ItemLoginAuthorization()(ItemScreen)}
+        />
+        <Route
+          path={MEMBER_PROFILE_PATH}
+          exact
+          component={Authorization()(MemberProfileScreen)}
+        />
+        <Route path={ITEMS_PATH} exact component={Authorization()(Home)} />
+        <Route
+          path={REDIRECT_PATH}
+          exact
+          component={Authorization()(Redirect)}
+        />
+        <Redirect to={HOME_PATH} />
+      </Switch>
     </Router>
   </ModalProviders>
 );

--- a/src/components/SharedItems.js
+++ b/src/components/SharedItems.js
@@ -10,6 +10,7 @@ import ErrorAlert from './common/ErrorAlert';
 import Items from './main/Items';
 import { hooks } from '../config/queryClient';
 import Loader from './common/Loader';
+import Main from './main/Main';
 
 const SharedItems = () => {
   const { t } = useTranslation();
@@ -24,14 +25,14 @@ const SharedItems = () => {
   }
 
   return (
-    <>
+    <Main>
       <ItemHeader />
       <Items
         id={SHARED_ITEMS_ID}
         title={t('Items Shared With Me')}
         items={List(sharedItems)}
       />
-    </>
+    </Main>
   );
 };
 

--- a/src/components/common/RedirectionContent.js
+++ b/src/components/common/RedirectionContent.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { REDIRECTION_CONTENT_ID } from '../../config/selectors';
+
+const RedirectionContent = ({ link }) => {
+  const { t } = useTranslation();
+  return (
+    <Link to={link}>
+      <Typography id={REDIRECTION_CONTENT_ID}>
+        {t('Click here if you are not automatically redirected')}
+      </Typography>
+    </Link>
+  );
+};
+
+RedirectionContent.propTypes = {
+  link: PropTypes.string.isRequired,
+};
+
+export default RedirectionContent;

--- a/src/components/common/SettingsHeader.js
+++ b/src/components/common/SettingsHeader.js
@@ -5,6 +5,7 @@ import Avatar from '@material-ui/core/Avatar';
 import Menu from '@material-ui/core/Menu';
 import Tooltip from '@material-ui/core/Tooltip';
 import Box from '@material-ui/core/Box';
+import { useHistory } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import truncate from 'lodash.truncate';
 import { MUTATION_KEYS, API_ROUTES } from '@graasp/query-client';
@@ -19,6 +20,7 @@ import {
   USER_MENU_SIGN_OUT_OPTION_ID,
 } from '../../config/selectors';
 import Loader from './Loader';
+import { MEMBER_PROFILE_PATH } from '../../config/paths';
 
 const useStyles = makeStyles((theme) => ({
   wrapper: {
@@ -34,9 +36,10 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function SettingsHeader() {
+const SettingsHeader = () => {
   const { data: user, isLoading } = hooks.useCurrentMember();
   const classes = useStyles();
+  const { push } = useHistory();
   const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState(null);
   const { mutate: signOut } = useMutation(MUTATION_KEYS.SIGN_OUT);
@@ -54,6 +57,10 @@ function SettingsHeader() {
     handleClose();
   };
 
+  const goToProfile = () => {
+    push(MEMBER_PROFILE_PATH);
+  };
+
   const renderMenu = () => {
     if (!user || user.isEmpty()) {
       return (
@@ -67,9 +74,12 @@ function SettingsHeader() {
     }
 
     return (
-      <MenuItem onClick={handleSignOut} id={USER_MENU_SIGN_OUT_OPTION_ID}>
-        {t('Sign Out')}
-      </MenuItem>
+      <>
+        <MenuItem onClick={goToProfile}>{t('Profile')}</MenuItem>
+        <MenuItem onClick={handleSignOut} id={USER_MENU_SIGN_OUT_OPTION_ID}>
+          {t('Sign Out')}
+        </MenuItem>
+      </>
     );
   };
 
@@ -107,6 +117,6 @@ function SettingsHeader() {
       </Menu>
     </>
   );
-}
+};
 
 export default SettingsHeader;

--- a/src/components/item/form/FolderForm.js
+++ b/src/components/item/form/FolderForm.js
@@ -39,11 +39,6 @@ FolderForm.propTypes = {
     }),
   }),
   onChange: PropTypes.func.isRequired,
-  classes: PropTypes.shape({
-    shortInputField: PropTypes.string.isRequired,
-    dialogContent: PropTypes.string.isRequired,
-    addedMargin: PropTypes.string.isRequired,
-  }).isRequired,
   item: PropTypes.shape({
     name: PropTypes.string,
     description: PropTypes.string,

--- a/src/components/main/Home.js
+++ b/src/components/main/Home.js
@@ -10,6 +10,7 @@ import FileUploader from './FileUploader';
 import { HOME_ERROR_ALERT_ID, OWNED_ITEMS_ID } from '../../config/selectors';
 import Loader from '../common/Loader';
 import ErrorAlert from '../common/ErrorAlert';
+import Main from './Main';
 
 const Home = () => {
   const { t } = useTranslation();
@@ -25,11 +26,11 @@ const Home = () => {
   }
 
   return (
-    <>
+    <Main>
       <FileUploader />
       <ItemHeader />
       <Items id={OWNED_ITEMS_ID} title={t('My Items')} items={List(ownItems)} />
-    </>
+    </Main>
   );
 };
 

--- a/src/components/main/ItemScreen.js
+++ b/src/components/main/ItemScreen.js
@@ -25,6 +25,7 @@ import Loader from '../common/Loader';
 import ErrorAlert from '../common/ErrorAlert';
 import { API_HOST } from '../../config/constants';
 import { ItemLayoutModeContext } from '../context/ItemLayoutModeContext';
+import Main from './Main';
 
 const { useChildren, useItem, useFileContent, useS3FileContent } = hooks;
 
@@ -144,7 +145,11 @@ const ItemScreen = () => {
     return <ErrorAlert id={ITEM_SCREEN_ERROR_ALERT_ID} />;
   }
 
-  return <ItemMain item={item}>{renderContent()}</ItemMain>;
+  return (
+    <Main>
+      <ItemMain item={item}>{renderContent()}</ItemMain>
+    </Main>
+  );
 };
 
 export default ItemScreen;

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Drawer from '@material-ui/core/Drawer';
 import clsx from 'clsx';
+import { Loader } from '@graasp/ui';
 import { makeStyles } from '@material-ui/core/styles';
+import { useTranslation } from 'react-i18next';
 import { CssBaseline } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import { HEADER_HEIGHT, LEFT_MENU_WIDTH } from '../../config/constants';
+import {
+  DEFAULT_LANG,
+  HEADER_HEIGHT,
+  LEFT_MENU_WIDTH,
+} from '../../config/constants';
 import MainMenu from './MainMenu';
 import Header from '../layout/Header';
+import { hooks } from '../../config/queryClient';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -55,8 +62,20 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Main = ({ children }) => {
+  const { i18n } = useTranslation();
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
+
+  const { data: member, isLoading } = hooks.useCurrentMember();
+
+  useEffect(() => {
+    i18n.changeLanguage(member?.get('extra')?.lang || DEFAULT_LANG);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [member?.get('extra')?.lang]);
+
+  if (isLoading) {
+    return <Loader />;
+  }
 
   const toggleDrawer = (isOpen) => {
     setOpen(isOpen);

--- a/src/components/main/Redirect.js
+++ b/src/components/main/Redirect.js
@@ -1,29 +1,18 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
-import { Link } from 'react-router-dom';
 import { useHistory } from 'react-router';
-import { useTranslation } from 'react-i18next';
 import { HOME_PATH } from '../../config/paths';
 import { REDIRECT_URL_LOCAL_STORAGE_KEY } from '../../config/constants';
+import RedirectionContent from '../common/RedirectionContent';
 
 const Redirect = () => {
   const { push } = useHistory();
-  const { t } = useTranslation();
 
   const nextPath =
     localStorage.getItem(REDIRECT_URL_LOCAL_STORAGE_KEY) ?? HOME_PATH;
 
   push(nextPath);
 
-  return (
-    <div>
-      <Link to={nextPath}>
-        <Typography>
-          {t('Click here if you are not automatically redirected')}
-        </Typography>
-      </Link>
-    </div>
-  );
+  return <RedirectionContent link={nextPath} />;
 };
 
 export default Redirect;

--- a/src/components/member/LanguageSwitch.js
+++ b/src/components/member/LanguageSwitch.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { MUTATION_KEYS } from '@graasp/query-client';
+import PropTypes from 'prop-types';
+import { FormControl, Select } from '@material-ui/core';
+import { langs } from '../../config/i18n';
+import { useMutation } from '../../config/queryClient';
+
+const LanguageSwitch = ({ id, memberId, lang }) => {
+  const { mutate: editMember } = useMutation(MUTATION_KEYS.EDIT_MEMBER);
+
+  const handleChange = (event) => {
+    editMember({
+      id: memberId,
+      extra: {
+        lang: event.target.value,
+      },
+    });
+  };
+
+  return (
+    <FormControl>
+      <Select id={id} native value={lang} onChange={handleChange}>
+        {Object.entries(langs).map(([l, name]) => (
+          <option value={l}>{name}</option>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+LanguageSwitch.propTypes = {
+  id: PropTypes.string,
+  memberId: PropTypes.string.isRequired,
+  lang: PropTypes.string.isRequired,
+};
+
+LanguageSwitch.defaultProps = {
+  id: null,
+};
+
+export default LanguageSwitch;

--- a/src/components/member/MemberProfileScreen.js
+++ b/src/components/member/MemberProfileScreen.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Grid, IconButton, makeStyles, Typography } from '@material-ui/core';
+import { Loader } from '@graasp/ui';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
+import Card from '@material-ui/core/Card';
+import { useTranslation } from 'react-i18next';
+import { ReactComponent as GraaspLogo } from '../../resources/graasp-logo.svg';
+import { hooks } from '../../config/queryClient';
+import LanguageSwitch from './LanguageSwitch';
+import { formatDate } from '../../utils/date';
+import { DEFAULT_LANG } from '../../config/constants';
+import { copyToClipboard } from '../../utils/clipboard';
+import {
+  MEMBER_PROFILE_MEMBER_ID_ID,
+  MEMBER_PROFILE_EMAIL_ID,
+  MEMBER_PROFILE_MEMBER_NAME_ID,
+  MEMBER_PROFILE_INSCRIPTION_DATE_ID,
+  MEMBER_PROFILE_LANGUAGE_SWITCH_ID,
+  MEMBER_PROFILE_MEMBER_ID_COPY_BUTTON_ID,
+} from '../../config/selectors';
+import notifier from '../../middlewares/notifier';
+import { COPY_MEMBER_ID_TO_CLIPBOARD } from '../../types/clipboard';
+import Main from '../main/Main';
+
+const useStyles = makeStyles((theme) => ({
+  profileTable: {
+    margin: theme.spacing(1, 0),
+  },
+  // todo: this will be replaced by a default image or the member avatar
+  logo: {
+    background: 'grey',
+    textAlign: 'center',
+  },
+}));
+
+const MemberProfileScreen = () => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const { data: member, isLoading } = hooks.useCurrentMember();
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  const copyIdToClipboard = () => {
+    copyToClipboard(member.get('id'), {
+      onSuccess: () => {
+        notifier({ type: COPY_MEMBER_ID_TO_CLIPBOARD.SUCCESS, payload: {} });
+      },
+      onError: () => {
+        notifier({ type: COPY_MEMBER_ID_TO_CLIPBOARD.FAILURE, payload: {} });
+      },
+    });
+  };
+
+  return (
+    <Main>
+      <Card className={classes.root}>
+        <Grid container spacing={3}>
+          {/* use the member avatar */}
+          <Grid item xs={4} className={classes.logo}>
+            <GraaspLogo height={250} />
+          </Grid>
+          <Grid item xs={8}>
+            <Grid item xs={12}>
+              <Typography variant="h4" id={MEMBER_PROFILE_MEMBER_NAME_ID}>
+                {member.get('name')}
+              </Typography>
+            </Grid>
+            {/* todo: display only as light user */}
+            <Grid
+              container
+              className={classes.profileTable}
+              alignItems="center"
+            >
+              <Grid item xs={4}>
+                <Typography>{t('Member ID')}</Typography>
+              </Grid>
+              <Grid item xs={8}>
+                <Typography id={MEMBER_PROFILE_MEMBER_ID_ID}>
+                  {member.get('id')}
+                  <IconButton
+                    id={MEMBER_PROFILE_MEMBER_ID_COPY_BUTTON_ID}
+                    onClick={copyIdToClipboard}
+                  >
+                    <FileCopyIcon />
+                  </IconButton>
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid
+              container
+              className={classes.profileTable}
+              alignItems="center"
+            >
+              <Grid item xs={4}>
+                <Typography>{t('Email')}</Typography>
+              </Grid>
+              <Grid item xs={8}>
+                <Typography id={MEMBER_PROFILE_EMAIL_ID}>
+                  {member.get('email')}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid
+              container
+              className={classes.profileTable}
+              alignItems="center"
+            >
+              <Grid item xs={4}>
+                <Typography>{t('Member Since')}</Typography>
+              </Grid>
+              <Grid item xs={8}>
+                <Typography id={MEMBER_PROFILE_INSCRIPTION_DATE_ID}>
+                  {formatDate(member.get('createdAt'))}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid
+              container
+              className={classes.profileTable}
+              alignItems="center"
+            >
+              <Grid item xs={4}>
+                <Typography>{t('Language')}</Typography>
+              </Grid>
+              <Grid item xs={8}>
+                <LanguageSwitch
+                  id={MEMBER_PROFILE_LANGUAGE_SWITCH_ID}
+                  memberId={member.get('id')}
+                  lang={member.get('extra')?.lang || DEFAULT_LANG}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Card>
+    </Main>
+  );
+};
+
+export default MemberProfileScreen;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -60,6 +60,7 @@ export const MIME_TYPES = {
 };
 export const DRAWER_WIDTH = 300;
 export const DEFAULT_LOCALE = 'en-US';
+export const DEFAULT_LANG = 'en';
 
 export const DEFAULT_PERMISSION_LEVEL = PERMISSION_LEVELS.WRITE;
 

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -38,3 +38,11 @@ export const POST_ITEM_TAG_ERROR_MESSAGE =
   'There was an error while posting the tag.';
 export const ITEM_LOGIN_SIGN_IN_ERROR_MESSAGE =
   'There was an error while signing in.';
+export const EDIT_MEMBER_ERROR_MESSAGE =
+  'There was an error updating the member';
+export const EDIT_MEMBER_SUCCESS_MESSAGE =
+  'The member was updated successfully';
+export const COPY_MEMBER_ID_TO_CLIPBOARD_SUCCESS_MESSAGE =
+  'Member ID is successfully copied!';
+export const COPY_MEMBER_ID_TO_CLIPBOARD_ERROR_MESSAGE =
+  'An error occured while copying the member ID';

--- a/src/config/paths.js
+++ b/src/config/paths.js
@@ -4,3 +4,4 @@ export const SIGN_UP_PATH = '/signUp';
 export const ITEMS_PATH = '/items';
 export const buildItemPath = (id = ':itemId') => `${ITEMS_PATH}/${id}`;
 export const REDIRECT_PATH = '/redirect';
+export const MEMBER_PROFILE_PATH = '/profile';

--- a/src/config/selectors.js
+++ b/src/config/selectors.js
@@ -82,3 +82,12 @@ export const ITEM_FORM_APP_URL_ID = 'itemFormAppUrl';
 export const VIEW_ITEM_EDIT_ITEM_BUTTON_ID = 'viewItemEditItemButton';
 export const TEXT_EDITOR_CLASS = 'ql-editor';
 export const buildSaveButtonId = (id) => `saveButton-${id}`;
+export const MEMBER_PROFILE_MEMBER_ID_ID = 'memberProfileMemberId';
+export const MEMBER_PROFILE_MEMBER_NAME_ID = 'memberProfileMemberName';
+export const MEMBER_PROFILE_EMAIL_ID = 'memberProfileEmail';
+export const MEMBER_PROFILE_INSCRIPTION_DATE_ID =
+  'memberProfileInscriptionDate';
+export const MEMBER_PROFILE_LANGUAGE_SWITCH_ID = 'memberProfileLanguageSwitch';
+export const MEMBER_PROFILE_MEMBER_ID_COPY_BUTTON_ID =
+  'memberProfileMemberIdCopyButton';
+export const REDIRECTION_CONTENT_ID = 'redirectionContent';

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -77,6 +77,11 @@
     "Create Shortcut": "Create Shortcut",
     "Sign Out": "Sign Out",
     "Confirm deleting item.": "Confirm deleting item",
-    "This item will be deleted permanently.": "This item will be deleted permanently."
+    "This item will be deleted permanently.": "This item will be deleted permanently.",
+    "Language": "Language",
+    "Storage Used": "Storage Used",
+    "Member Since": "Member Since",
+    "Profile": "Profile",
+    "Member ID": "Member ID"
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -77,6 +77,11 @@
     "Create Shortcut": "Créer un Raccourci",
     "Sign Out": "Déconnexion",
     "Confirm deleting item.": "Confirmer la suppression de l'élément",
-    "This item will be deleted permanently.": "Cet élément sera supprimé définitivement."
+    "This item will be deleted permanently.": "Cet élément sera supprimé définitivement.",
+    "Language": "Langue",
+    "Storage Used": "Mémoire utilisée",
+    "Member Since": "Membre depuis",
+    "Profile": "Profil",
+    "Member ID": "ID de Membre"
   }
 }

--- a/src/middlewares/notifier.js
+++ b/src/middlewares/notifier.js
@@ -25,7 +25,12 @@ import {
   POST_ITEM_TAG_ERROR_MESSAGE,
   DELETE_ITEM_TAG_ERROR_MESSAGE,
   ITEM_LOGIN_SIGN_IN_ERROR_MESSAGE,
+  EDIT_MEMBER_ERROR_MESSAGE,
+  EDIT_MEMBER_SUCCESS_MESSAGE,
+  COPY_MEMBER_ID_TO_CLIPBOARD_SUCCESS_MESSAGE,
+  COPY_MEMBER_ID_TO_CLIPBOARD_ERROR_MESSAGE,
 } from '../config/messages';
+import { COPY_MEMBER_ID_TO_CLIPBOARD } from '../types/clipboard';
 
 const {
   createItemRoutine,
@@ -40,12 +45,21 @@ const {
   postItemTagRoutine,
   deleteItemTagRoutine,
   postItemLoginRoutine,
+  editMemberRoutine,
 } = routines;
 
 export default ({ type, payload }) => {
   let message = null;
   switch (type) {
     // error messages
+    case COPY_MEMBER_ID_TO_CLIPBOARD.FAILURE: {
+      message = COPY_MEMBER_ID_TO_CLIPBOARD_ERROR_MESSAGE;
+      break;
+    }
+    case editMemberRoutine.FAILURE: {
+      message = EDIT_MEMBER_ERROR_MESSAGE;
+      break;
+    }
     case createItemRoutine.FAILURE: {
       message = CREATE_ITEM_ERROR_MESSAGE;
       break;
@@ -92,6 +106,10 @@ export default ({ type, payload }) => {
       break;
     }
     // success messages
+    case editMemberRoutine.SUCCESS: {
+      message = EDIT_MEMBER_SUCCESS_MESSAGE;
+      break;
+    }
     case createItemRoutine.SUCCESS: {
       message = CREATE_ITEM_SUCCESS_MESSAGE;
       break;
@@ -123,6 +141,10 @@ export default ({ type, payload }) => {
     }
     case signOutRoutine.SUCCESS: {
       message = SIGN_OUT_SUCCESS_MESSAGE;
+      break;
+    }
+    case COPY_MEMBER_ID_TO_CLIPBOARD.SUCCESS: {
+      message = COPY_MEMBER_ID_TO_CLIPBOARD_SUCCESS_MESSAGE;
       break;
     }
 

--- a/src/types/clipboard.js
+++ b/src/types/clipboard.js
@@ -1,0 +1,6 @@
+// todo: use create routine from utils
+// eslint-disable-next-line import/prefer-default-export
+export const COPY_MEMBER_ID_TO_CLIPBOARD = {
+  SUCCESS: 'COPY_MEMBER_ID_TO_CLIPBOARD/SUCCESS',
+  FAILURE: 'COPY_MEMBER_ID_TO_CLIPBOARD/FAILURE',
+};

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/prefer-default-export
+export const copyToClipboard = (string, { onSuccess, onError }) => {
+  // check can write to clipboard
+  navigator.permissions.query({ name: 'clipboard-write' }).then((result) => {
+    if (result.state === 'granted' || result.state === 'prompt') {
+      // write to clipboard
+      navigator.clipboard
+        .writeText(string)
+        .then(() => onSuccess?.())
+        .catch(() => onError?.());
+    } else {
+      onError?.();
+    }
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,9 +1583,9 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@graasp/query-client@git://github.com/graasp/graasp-query-client.git#5/patchMember":
+"@graasp/query-client@git://github.com/graasp/graasp-query-client.git":
   version "0.1.0"
-  resolved "git://github.com/graasp/graasp-query-client.git#5397cd3fbb27d7703c61d57a34c7c2f1083280ff"
+  resolved "git://github.com/graasp/graasp-query-client.git#05bde46fec71ed84aa6ca4ae0e5753ba78c677ae"
   dependencies:
     http-status-codes "2.1.4"
     immutable "4.0.0-rc.12"
@@ -1594,9 +1594,9 @@
     react-query "3.16.0"
     uuid "8.3.2"
 
-"@graasp/ui@git://github.com/graasp/graasp-ui.git#14/captions":
+"@graasp/ui@git://github.com/graasp/graasp-ui.git#master":
   version "0.2.0"
-  resolved "git://github.com/graasp/graasp-ui.git#e8659334d6fe8a8e28fa4c3f41a467f58de79a69"
+  resolved "git://github.com/graasp/graasp-ui.git#97c65d25464dc8ba944ce35722d2bad5a16d834f"
   dependencies:
     clsx "1.1.1"
     immutable "4.0.0-rc.12"
@@ -2313,9 +2313,9 @@
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
 "@types/node@*":
-  version "15.12.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.3.tgz#2817bf5f25bc82f56579018c53f7d41b1830b1af"
-  integrity sha512-SNt65CPCXvGNDZ3bvk1TQ0Qxoe3y1RKH88+wZ2Uf05dduBCqqFQ76ADP9pbT+Cpvj60SkRppMCh2Zo8tDixqjQ==
+  version "15.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
+  integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4257,9 +4257,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219:
-  version "1.0.30001238"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz#e6a8b45455c5de601718736d0242feef0ecdda15"
-  integrity sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw==
+  version "1.0.30001239"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
+  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4963,7 +4963,7 @@ conventional-recommended-bump@6.0.11:
     meow "^8.0.0"
     q "^1.5.1"
 
-convert-source-map@1.7.0, convert-source-map@^1.1.0, convert-source-map@^1.3.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4974,6 +4974,13 @@ convert-source-map@^0.3.3:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
   integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
+
+convert-source-map@^1.1.0, convert-source-map@^1.3.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
+  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 convert-source-map@~1.1.0:
   version "1.1.3"
@@ -5008,17 +5015,17 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.1.1, core-js-compat@^3.14.0, core-js-compat@^3.6.2:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.14.0.tgz#b574dabf29184681d5b16357bd33d104df3d29a5"
-  integrity sha512-R4NS2eupxtiJU+VwgkF9WTpnSfZW4pogwKHd8bclWU2sp93Pr5S1uYJI84cMOubJRou7bcfL0vmwtLslWN5p3A==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.15.0.tgz#e14a371123db9d1c5b41206d3f420643d238b8fa"
+  integrity sha512-8X6lWsG+s7IfOKzV93a7fRYfWRZobOfjw5V5rrq43Vh/W+V6qYxl7Akalsvgab4PFT/4L/pjQbdBUEM36NXKrw==
   dependencies:
     browserslist "^4.16.6"
     semver "7.0.0"
 
 core-js-pure@^3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.14.0.tgz#72bcfacba74a65ffce04bf94ae91d966e80ee553"
-  integrity sha512-YVh+LN2FgNU0odThzm61BsdkwrbrchumFq3oztnE9vTKC4KS2fvnPmcx8t6jnqAyOTCTF4ZSiuK8Qhh7SNcL4g==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.0.tgz#c19349ae0be197b8bcf304acf4d91c5e29ae2091"
+  integrity sha512-RO+LFAso8DB6OeBX9BAcEGvyth36QtxYon1OyVsITNVtSKr/Hos0BXZwnsOJ7o+O6KHtK+O+cJIEj9NGg6VwFA==
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -5026,9 +5033,9 @@ core-js@^2.4.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.6.1, core-js@^3.6.5:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.14.0.tgz#62322b98c71cc2018b027971a69419e2425c2a6c"
-  integrity sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.0.tgz#db9554ebce0b6fd90dc9b1f2465c841d2d055044"
+  integrity sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -6409,9 +6416,9 @@ eslint-webpack-plugin@^2.1.0:
     schema-utils "^3.0.0"
 
 eslint@^7.11.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.28.0.tgz#435aa17a0b82c13bb2be9d51408b617e49c1e820"
-  integrity sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.29.0.tgz#ee2a7648f2e729485e4d0bd6383ec1deabc8b3c0"
+  integrity sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.2"
@@ -15365,9 +15372,9 @@ yargs-parser@^18.1.2:
     decamelize "^1.2.0"
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.7"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
-  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs@^13.3.2:
   version "13.3.2"


### PR DESCRIPTION
This PR adds a page for the user to see his information. I added minor features such as:
- change language
- copy member id (useful for light users mainly)

<img width="908" alt="Screenshot 2021-06-16 at 17 09 55" src="https://user-images.githubusercontent.com/11229627/122245064-aeb66400-cec5-11eb-8aa0-d768519526df.png">
(yes my name is 33)

At some point we would add the further feature:
- edit avatar
- update password
- update mail (but this one requires more work on the backend)
- regular user: show folders?
- light user: show memberships

close #57 