### PR TITLE
fix: prevent spam click of confirm button which creates many same items

### DIFF
--- a/src/components/main/NewItemModal.js
+++ b/src/components/main/NewItemModal.js
@@ -31,9 +31,13 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+// time to be considered between 2 clicks for a double-click (https://en.wikipedia.org/wiki/Double-click#Speed_and_timing)
+const DOUBLE_CLICK_DELAY_MS = 500;
+
 const NewItemModal = ({ open, handleClose }) => {
   const { t } = useTranslation();
   const classes = useStyles();
+  const [isConfirmButtonDisabled, setConfirmButtonDisabled] = useState(false);
   const [selectedItemType, setSelectedItemType] = useState(ITEM_TYPES.FOLDER);
   const [initialItem] = useState({});
   const [currentType, setCurrentType] = useState(ITEM_TYPES.FOLDER);
@@ -67,12 +71,18 @@ const NewItemModal = ({ open, handleClose }) => {
   }, [selectedItemType]);
 
   const submit = () => {
+    if (isConfirmButtonDisabled) {
+      return false;
+    }
     if (!isItemValid(updatedPropertiesPerType[currentType])) {
       // todo: notify user
       return false;
     }
 
+    setConfirmButtonDisabled(true);
     postItem({ parentId, ...updatedPropertiesPerType[currentType] });
+    // schedule button disable state reset AFTER end of click event handling
+    setTimeout(() => setConfirmButtonDisabled(false), DOUBLE_CLICK_DELAY_MS);
     return handleClose();
   };
 
@@ -140,7 +150,10 @@ const NewItemModal = ({ open, handleClose }) => {
               onClick={submit}
               color="primary"
               id={ITEM_FORM_CONFIRM_BUTTON_ID}
-              disabled={!isItemValid(updatedPropertiesPerType[currentType])}
+              disabled={
+                isConfirmButtonDisabled ||
+                !isItemValid(updatedPropertiesPerType[currentType])
+              }
             >
               {t('Add')}
             </Button>


### PR DESCRIPTION
This bugfix prevents a user to maliciously or accidentally spam the "confirm" button in the "New item" modal, which resulted in many items with the same properties being created, see:
- #126 

It uses local component state to keep track of whether or not the button should be disabled, and schedules a re-enable 500ms after the click event (default Windows timing to detect a double click, as it is not standardized https://en.wikipedia.org/wiki/Double-click#Speed_and_timing)