### PR TITLE
fix: case-insensitive autocomplete comparison

### DIFF
--- a/src/components/item/form/AppForm.tsx
+++ b/src/components/item/form/AppForm.tsx
@@ -89,7 +89,7 @@ const AppForm: FC<Props> = ({ onChange, item, updatedProperties = {} }) => {
           }}
           filterOptions={(options, state) => {
             const filteredOptionsByName = options.filter((opt: RecordOf<App>) =>
-              opt.name.includes(state.inputValue),
+              opt.name.toLowerCase().includes(state.inputValue.toLowerCase()),
             );
             return filteredOptionsByName;
           }}

--- a/src/components/item/settings/ItemSettings.tsx
+++ b/src/components/item/settings/ItemSettings.tsx
@@ -183,8 +183,7 @@ const ItemSettings: FC<Props> = ({ item }) => {
         {renderPinSetting()}
         {renderChatSetting()}
         {renderCollapseSetting()}
-        {/* todo: change itemType to app */}
-        {item.type === ItemType.FOLDER && renderResizeSetting()}
+        {item.type === ItemType.APP && renderResizeSetting()}
       </FormGroup>
       {item.type === ItemType.LINK && <LinkSettings item={item} />}
       <ThumbnailSetting item={item} />


### PR DESCRIPTION
This PR fixes dumb issues created in #514:
- comparison of the strings should be made in lowercase
- resizable setting should be show when `ItemType` is `app`

closes #528 