### PR TITLE
feat: add tutorial footer menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@graasp/query-client": "0.1.3",
     "@graasp/sdk": "0.3.0",
     "@graasp/translations": "1.3.0",
-    "@graasp/ui": "0.8.0",
+    "@graasp/ui": "0.9.0",
     "@mui/icons-material": "5.11.0",
     "@mui/lab": "5.0.0-alpha.117",
     "@mui/material": "5.11.6",

--- a/src/components/main/MainMenu.tsx
+++ b/src/components/main/MainMenu.tsx
@@ -1,14 +1,19 @@
+import AutoStoriesIcon from '@mui/icons-material/AutoStories';
 import DeleteIcon from '@mui/icons-material/Delete';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FolderIcon from '@mui/icons-material/Folder';
 import FolderSharedIcon from '@mui/icons-material/FolderShared';
+import { styled } from '@mui/material';
+import ListItemIcon from '@mui/material/ListItemIcon';
 
 import { FC, useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import { BUILDER } from '@graasp/translations';
 import { MainMenu as GraaspMainMenu, MenuItem } from '@graasp/ui';
 
+import { TUTORIALS_LINK } from '../../config/constants';
 import { useBuilderTranslation } from '../../config/i18n';
 import {
   FAVORITE_ITEMS_PATH,
@@ -18,15 +23,40 @@ import {
 } from '../../config/paths';
 import { CurrentUserContext } from '../context/CurrentUserContext';
 
+const StyledLink = styled(Link)(({ theme }) => ({
+  position: 'absolute',
+  bottom: 0,
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(2),
+  boxSizing: 'border-box',
+  color: 'grey',
+  textDecoration: 'none',
+  '&:hover': {
+    color: theme.palette.primary.main,
+  },
+}));
+
 const MainMenu: FC = () => {
   const { t: translateBuilder } = useBuilderTranslation();
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const { t } = useBuilderTranslation();
   const { data: member } = useContext(CurrentUserContext);
 
   const goTo = (path: string) => {
     navigate(path);
   };
+
+  const resourcesLink = (
+    <StyledLink to={TUTORIALS_LINK}>
+      <ListItemIcon>
+        <AutoStoriesIcon />
+      </ListItemIcon>
+      {t('Tutorials')}
+    </StyledLink>
+  );
 
   const renderAuthenticatedMemberMenuItems = () => {
     if (!member || !member.id) {
@@ -70,7 +100,10 @@ const MainMenu: FC = () => {
   };
 
   return (
-    <GraaspMainMenu>{renderAuthenticatedMemberMenuItems()}</GraaspMainMenu>
+    <GraaspMainMenu fullHeight>
+      {renderAuthenticatedMemberMenuItems()}
+      {resourcesLink}
+    </GraaspMainMenu>
   );
 };
 

--- a/src/components/main/MainMenu.tsx
+++ b/src/components/main/MainMenu.tsx
@@ -8,7 +8,6 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 
 import { FC, useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { Link } from 'react-router-dom';
 
 import { BUILDER } from '@graasp/translations';
 import { MainMenu as GraaspMainMenu, MenuItem } from '@graasp/ui';
@@ -23,7 +22,7 @@ import {
 } from '../../config/paths';
 import { CurrentUserContext } from '../context/CurrentUserContext';
 
-const StyledLink = styled(Link)(({ theme }) => ({
+const StyledLink = styled('a')(({ theme }) => ({
   position: 'absolute',
   bottom: 0,
   width: '100%',
@@ -33,6 +32,11 @@ const StyledLink = styled(Link)(({ theme }) => ({
   boxSizing: 'border-box',
   color: 'grey',
   textDecoration: 'none',
+  '&:hover': {
+    color: theme.palette.primary.main,
+  },
+}));
+const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
   '&:hover': {
     color: theme.palette.primary.main,
   },
@@ -50,7 +54,7 @@ const MainMenu: FC = () => {
   };
 
   const resourcesLink = (
-    <StyledLink to={TUTORIALS_LINK}>
+    <StyledLink href={TUTORIALS_LINK} target="_blank">
       <ListItemIcon>
         <AutoStoriesIcon />
       </ListItemIcon>
@@ -61,7 +65,7 @@ const MainMenu: FC = () => {
   const renderAuthenticatedMemberMenuItems = () => {
     if (!member || !member.id) {
       return (
-        <MenuItem
+        <StyledMenuItem
           disabled
           text={translateBuilder(BUILDER.HOME_TITLE)}
           icon={<FolderIcon />}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -272,4 +272,3 @@ export const GRAASP_ASSETS_URL = process.env.REACT_APP_GRAASP_ASSETS_URL;
 // TODO: refer from specific endpoint /tutorials?
 export const TUTORIALS_LINK =
   'https://player.graasp.org/9d80d81f-ec9d-4bfb-836a-1c6b125aef2f';
-

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -269,5 +269,7 @@ export const DEFAULT_LINK_SHOW_BUTTON = true;
 
 export const GRAASP_ASSETS_URL = process.env.REACT_APP_GRAASP_ASSETS_URL;
 
+// TODO: refer from specific endpoint /tutorials?
 export const TUTORIALS_LINK =
   'https://player.graasp.org/9d80d81f-ec9d-4bfb-836a-1c6b125aef2f';
+

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -268,3 +268,6 @@ export const DEFAULT_LINK_SHOW_IFRAME = false;
 export const DEFAULT_LINK_SHOW_BUTTON = true;
 
 export const GRAASP_ASSETS_URL = process.env.REACT_APP_GRAASP_ASSETS_URL;
+
+export const TUTORIALS_LINK =
+  'https://player.graasp.org/9d80d81f-ec9d-4bfb-836a-1c6b125aef2f';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,9 +2563,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/ui@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@graasp/ui@npm:0.8.0"
+"@graasp/ui@npm:0.9.0":
+  version: 0.9.0
+  resolution: "@graasp/ui@npm:0.9.0"
   dependencies:
     "@graasp/sdk": 0.2.0
     clsx: 1.1.1
@@ -2598,7 +2598,7 @@ __metadata:
       optional: true
     ag-grid-react:
       optional: true
-  checksum: 800d6b8d6d444c24594685acc0b7d82b5331bdf8be18676e8f26308b45c8ec131531f4953b11b19882d25c0c4dbd2052d5bf3af0236bbf83fe4bf227909609ae
+  checksum: 2e2df0cea62e62c189f7c9a69281a67451423b8cb630f282f34a5ca79987805f03e7bea564eb5f70a0037f55d5493f7c53478cd452d8f692aa617fd346c95ab6
   languageName: node
   linkType: hard
 
@@ -10142,7 +10142,7 @@ __metadata:
     "@graasp/query-client": 0.1.3
     "@graasp/sdk": 0.3.0
     "@graasp/translations": 1.3.0
-    "@graasp/ui": 0.8.0
+    "@graasp/ui": 0.9.0
     "@graasp/websockets": "github:graasp/graasp-websockets.git"
     "@mui/icons-material": 5.11.0
     "@mui/lab": 5.0.0-alpha.117


### PR DESCRIPTION
close #545

<img width="912" alt="Screenshot 2023-02-06 at 15 55 47" src="https://user-images.githubusercontent.com/11229627/217008380-b1e090cc-3bb4-4650-8d99-c1b6fb544349.png">


After some feedback I've been suggested to add the tutorials' link at some place in builder. I think the footer is a good place so it's not too highlighted, but I'm happy to get your feedback.