### PR TITLE
fix: remove player button from item header actions

### DIFF
--- a/cypress/support/viewUtils.js
+++ b/cypress/support/viewUtils.js
@@ -19,7 +19,6 @@ import {
   TEXT_EDITOR_CLASS,
   buildEditButtonId,
   buildFileItemId,
-  buildPlayerButtonId,
   buildSettingsButtonId,
   buildShareButtonId,
 } from '../../src/config/selectors';
@@ -53,7 +52,6 @@ export const expectItemHeaderLayout = ({
   const header = cy.get(`#${ITEM_HEADER_ID}`);
 
   header.get(`#${buildShareButtonId(id)}`).should('exist');
-  header.get(`#${buildPlayerButtonId(id)}`).should('exist');
 
   if (
     isSettingsEditionAllowedForUser({

--- a/src/components/item/header/ItemHeaderActions.tsx
+++ b/src/components/item/header/ItemHeaderActions.tsx
@@ -17,7 +17,6 @@ import {
 import AnalyticsDashboardButton from '../../common/AnalyticsDashboardButton';
 import EditItemCaptionButton from '../../common/EditItemCaptionButton';
 import ItemMetadataButton from '../../common/ItemMetadataButton';
-import PlayerViewButton from '../../common/PlayerViewButton';
 import PublishButton from '../../common/PublishButton';
 import ShareButton from '../../common/ShareButton';
 import { useCurrentUserContext } from '../../context/CurrentUserContext';
@@ -76,7 +75,6 @@ const ItemHeaderActions = ({ item }: Props): JSX.Element => {
             id={ITEM_CHATBOX_BUTTON_ID}
             onClick={onClickChatbox}
           />
-          <PlayerViewButton itemId={id} />
           {canAdmin && <PublishButton itemId={id} />}
           {canEdit && <AnalyticsDashboardButton id={id} />}
         </>


### PR DESCRIPTION
This PR removes the player button from the item header actions.

closes #574 