### PR TITLE
fix(quill): save empty string when content is empty

### DIFF
--- a/src/components/item/FolderDescription.tsx
+++ b/src/components/item/FolderDescription.tsx
@@ -25,7 +25,13 @@ const FolderDescription: FC<Props> = ({ itemId, isEditing = false }) => {
   const { data: parentItem } = hooks.useItem(itemId);
 
   const onDescriptionSave = (str: string) => {
-    editItem({ id: itemId, description: str });
+    let description = str;
+    // check that the content is just empty
+    // this is added by quills internal model based on deltas https://quilljs.com/docs/delta/
+    if (str === '<p><br></p>') {
+      description = '';
+    }
+    editItem({ id: itemId, description });
     setEditingItemId(null);
   };
 


### PR DESCRIPTION
This PR ensures that the content saved by the text editor is an empty string when the editor is cleared.

closes #570 