### PR TITLE
fix: use `CustomInitialLoader` on first load

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router';
 import { Route, Routes } from 'react-router-dom';
 
 import { saveUrlForRedirection } from '@graasp/sdk';
-import { Loader, withAuthorization } from '@graasp/ui';
+import { CustomInitialLoader, withAuthorization } from '@graasp/ui';
 
 import { DOMAIN, SIGN_IN_PATH } from '../config/constants';
 import {
@@ -30,7 +30,7 @@ const App: FC = () => {
   const { data: currentMember, isLoading } = useCurrentUserContext();
 
   if (isLoading) {
-    return <Loader />;
+    return <CustomInitialLoader />;
   }
 
   const withAuthorizationProps = {


### PR DESCRIPTION
This PR uses the `CustomInitialLoader` from @graasp/ui for the first screen when the builder is fetching the member. 

It would be super cool be able to statically generate that in the `idnex.html` so there is no "white screen of death" when the bundle takes a bit longer to load.
Maybe this could be accomplished when using vite ?

closes #587
