### PR TITLE
feat: adds required symbol for name of folder, document and etherpad

### DIFF
--- a/src/components/item/form/BaseItemForm.tsx
+++ b/src/components/item/form/BaseItemForm.tsx
@@ -13,9 +13,15 @@ type Props = {
   updatedProperties: Partial<DiscriminatedItem<UnknownExtra>>;
   onChange: (props: Partial<DiscriminatedItem>) => void;
   item: Partial<ItemRecord>;
+  required?: boolean;
 };
 
-const BaseForm: FC<Props> = ({ onChange, item, updatedProperties }) => {
+const BaseForm: FC<Props> = ({
+  onChange,
+  item,
+  required,
+  updatedProperties,
+}) => {
   const { t: translateBuilder } = useBuilderTranslation();
 
   const handleNameInput = (event: ChangeEvent<{ value: string }>) => {
@@ -26,6 +32,7 @@ const BaseForm: FC<Props> = ({ onChange, item, updatedProperties }) => {
     <TextField
       variant="standard"
       autoFocus
+      required={required}
       id={ITEM_FORM_NAME_INPUT_ID}
       label={translateBuilder(BUILDER.CREATE_NEW_ITEM_NAME_LABEL)}
       value={updatedProperties?.name ?? item?.name}

--- a/src/components/item/form/DocumentForm.tsx
+++ b/src/components/item/form/DocumentForm.tsx
@@ -142,6 +142,7 @@ const DocumentForm = ({
         <BaseForm
           onChange={onChange}
           item={item}
+          required
           updatedProperties={updatedProperties}
         />
       </Box>

--- a/src/components/item/form/EtherpadForm.tsx
+++ b/src/components/item/form/EtherpadForm.tsx
@@ -23,6 +23,7 @@ const useEtherpadForm = (): { padName: string; EtherpadForm: FC } => {
         <TextField
           variant="standard"
           autoFocus
+          required
           id={ITEM_FORM_ETHERPAD_NAME_INPUT_ID}
           label={translateBuilder(BUILDER.CREATE_NEW_ITEM_ETHERPAD_LABEL)}
           value={padName}

--- a/src/components/item/form/FolderForm.tsx
+++ b/src/components/item/form/FolderForm.tsx
@@ -30,6 +30,7 @@ const FolderForm = ({
       <BaseItemForm
         onChange={onChange}
         item={item}
+        required
         updatedProperties={updatedProperties}
       />
 


### PR DESCRIPTION
Closes #619

Adds a * to the name text input field for `Folder`, `Document` and `Etherpad`.

<img width="746" alt="Screenshot 2023-05-03 at 16 16 45" src="https://user-images.githubusercontent.com/56155987/235943296-cbdce743-3a56-4704-98b6-911505068f06.png">


Might want use `BaseItemForm` in `EtherpadForm`? 