### PR TITLE
fix(link): allow all non-whitespace chars in urls

### DIFF
--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -86,8 +86,9 @@ export const isUrlValid = (str?: string | null): boolean => {
       '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
       '((\\d{1,3}\\.){3}\\d{1,3})|' + // OR ip (v4) address
       'localhost)' + // OR localhost alias
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-      '(\\?\\S*)?' + // query string
+      '(\\:\\d+)?' + // post (optional)
+      '(\\/\\S*?)*' + // path (lazy: takes as few as possible)
+      '(\\?\\S*?)?' + // query string (lazy)
       '(\\#\\S*)?$', // fragment locator
     'i',
   );

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -87,7 +87,7 @@ export const isUrlValid = (str?: string | null): boolean => {
       '((\\d{1,3}\\.){3}\\d{1,3})|' + // OR ip (v4) address
       'localhost)' + // OR localhost alias
       '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      '(\\?\\S*)?' + // query string
       '(\\#\\S*)?$', // fragment locator
     'i',
   );


### PR DESCRIPTION
This PR proposes to simplify the validation of urls to allow some urls that currently fail. See #756 

[Test urls](https://regex101.com/r/iOZk6g/2)

@dialexo Do you think we would expose to possible security threats by allowing all non-whitespace characters in urls ?

