### PR TITLE
fix: use `??` instead of `||` for skeleton in `AppCard.tsx`

### DIFF
--- a/src/components/main/AppCard.tsx
+++ b/src/components/main/AppCard.tsx
@@ -58,7 +58,7 @@ const AppCard = ({
       />
       <CardContent sx={{ width: '100%' }}>
         <Typography gutterBottom variant="subtitle2" component="div">
-          {name || <Skeleton />}
+          {name ?? <Skeleton />}
         </Typography>
         <Typography
           variant="body2"
@@ -70,7 +70,7 @@ const AppCard = ({
             WebkitLineClamp: 3,
           }}
         >
-          {description || <Skeleton height={45} />}
+          {description ?? <Skeleton height={45} />}
         </Typography>
       </CardContent>
     </StyledCardActionArea>


### PR DESCRIPTION
This should fix the issue of the description staying in "loading" mode when it is an empty string.
With `??` it will only show the skeleton when the data is not yet available. 

Example below, the apps have loaded but the description of Task Management and Text Input are simply `""` so they show the Skeleton even if they are loaded:
<img width="731" alt="Screenshot 2023-10-16 at 21 34 46" src="https://github.com/graasp/graasp-builder/assets/39373170/cd720f63-e37b-4e92-b90c-954e15fcc09c">
