### PR TITLE
fix: use 100% for crop

### DIFF
--- a/src/components/common/CropModal.tsx
+++ b/src/components/common/CropModal.tsx
@@ -32,7 +32,7 @@ function centerAspectCrop(
     makeAspectCrop(
       {
         unit: '%',
-        width: 90,
+        width: 100,
       },
       aspect,
       mediaWidth,


### PR DESCRIPTION
Start the crop at 100% of the input image.