### PR TITLE
fix: make thumbnails nice in grid view

### DIFF
--- a/src/components/main/ItemCard.tsx
+++ b/src/components/main/ItemCard.tsx
@@ -6,6 +6,7 @@ import {
   ItemMembership,
   ItemType,
   PermissionLevel,
+  ThumbnailSize,
 } from '@graasp/sdk';
 import { Card as GraaspCard, Thumbnail } from '@graasp/ui';
 
@@ -53,7 +54,10 @@ const ItemComponent = ({
   canMove = true,
 }: Props): JSX.Element => {
   const { id, name } = item;
-  const { data: thumbnailUrl, isLoading } = hooks.useItemThumbnailUrl({ id });
+  const { data: thumbnailUrl, isLoading } = hooks.useItemThumbnailUrl({
+    id,
+    size: ThumbnailSize.Medium,
+  });
 
   const alt = name;
   const defaultValueComponent = (
@@ -80,6 +84,7 @@ const ItemComponent = ({
       url={thumbnailUrl ?? linkUrl}
       alt={alt}
       defaultComponent={defaultValueComponent}
+      sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
     />
   );
 

--- a/src/components/table/ItemNameCellRenderer.tsx
+++ b/src/components/table/ItemNameCellRenderer.tsx
@@ -31,7 +31,6 @@ const ItemNameCellRenderer = (
         iconSrc={iconSrc}
         alt={alt}
         mimetype={getMimetype(item.extra)}
-        sx={{ border: '2px solid red' }}
       />
     );
 

--- a/src/components/table/ItemNameCellRenderer.tsx
+++ b/src/components/table/ItemNameCellRenderer.tsx
@@ -1,6 +1,11 @@
 import { Box, Typography } from '@mui/material';
 
-import { DiscriminatedItem, ItemType, getEmbeddedLinkExtra } from '@graasp/sdk';
+import {
+  DiscriminatedItem,
+  ItemType,
+  getEmbeddedLinkExtra,
+  getMimetype,
+} from '@graasp/sdk';
 import { ItemIcon, Thumbnail } from '@graasp/ui';
 
 import { hooks } from '../../config/queryClient';
@@ -25,11 +30,8 @@ const ItemNameCellRenderer = (
         type={item.type}
         iconSrc={iconSrc}
         alt={alt}
-        extra={
-          item.type === ItemType.S3_FILE || item.type === ItemType.LOCAL_FILE
-            ? item.extra
-            : undefined
-        }
+        mimetype={getMimetype(item.extra)}
+        sx={{ border: '2px solid red' }}
       />
     );
 


### PR DESCRIPTION
This PR updates the size used for thumbnails in the Grid and their styling:

Before:
<img width="1294" alt="Screenshot 2024-02-05 at 13 33 06" src="https://github.com/graasp/graasp-builder/assets/39373170/abb6c312-b7b1-4e89-8bde-e2dc4524f3c8">

After:
<img width="1297" alt="Screenshot 2024-02-05 at 13 33 44" src="https://github.com/graasp/graasp-builder/assets/39373170/19fb25b4-d2e4-4d66-b17a-a9b5cca26fee">

