### PR TITLE
fix(chore): set FormControlLabel max width to limit show only me switch

### DIFF
--- a/src/components/main/ItemsToolbar.tsx
+++ b/src/components/main/ItemsToolbar.tsx
@@ -38,6 +38,7 @@ const ItemsToolbar = ({
       <Stack direction="column" mt={2} mb={2} spacing={1}>
         {onShowOnlyMeChange && (
           <FormControlLabel
+            sx={{ maxWidth: 'max-content' }}
             control={
               <Switch
                 id={ACCESSIBLE_ITEMS_ONLY_ME_ID}


### PR DESCRIPTION
This fix #1001.

<img width="568" alt="image" src="https://github.com/graasp/graasp-builder/assets/147397675/124d637b-dadc-4519-94e0-172bd117b5a0">
