### PR TITLE
chore: cleanup old code and use sdk functions

### DIFF
--- a/cypress/e2e/item/hide/hideItem.cy.ts
+++ b/cypress/e2e/item/hide/hideItem.cy.ts
@@ -53,8 +53,8 @@ const ITEM = PackedFolderItemFactory(
 );
 
 const toggleHideButton = (itemId: string, isHidden = false) => {
-  // todo: remove on table refactor
-  cy.wait(500);
+  // table re-renders when this resolves, so we wait for the call to be made
+  cy.wait('@getManyPublishItemInformations');
   const menuSelector = `#${buildItemMenuButtonId(itemId)}`;
   cy.get(menuSelector).click();
 

--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -19,6 +19,7 @@ import {
   ShortLink,
   ShortLinkPayload,
   buildPathFromIds,
+  getIdsFromPath,
   isRootItem,
 } from '@graasp/sdk';
 import { FAILURE_MESSAGES } from '@graasp/translations';
@@ -27,7 +28,6 @@ import { StatusCodes } from 'http-status-codes';
 import { v4 as uuidv4, v4 } from 'uuid';
 
 import { SETTINGS } from '../../src/config/constants';
-import { getItemById } from '../../src/utils/item';
 import { getMemberById } from '../../src/utils/member';
 import {
   buildAppApiAccessTokenRoute,
@@ -43,6 +43,7 @@ import {
   ID_FORMAT,
   SHORTLINK_FORMAT,
   extractItemIdOrThrow,
+  getItemById,
   parseStringToRegExp,
 } from './utils';
 
@@ -433,9 +434,14 @@ export const mockGetChildren = ({
     ({ url, reply }) => {
       const id = url.slice(API_HOST.length).split('/')[2];
       const item = getItemById(items, id);
-
-      const children = items.filter((elem) => isRootItem(elem));
-
+      const itemDepthLevel = getIdsFromPath(item.path).length;
+      const children = items.filter(
+        (elem) =>
+          // should be a descendant of the the item
+          elem.path.startsWith(item.path) &&
+          // should be a direct child
+          getIdsFromPath(elem.path).length === itemDepthLevel + 1,
+      );
       if (item.public) {
         return reply(children);
       }

--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -18,6 +18,8 @@ import {
   RecycledItemData,
   ShortLink,
   ShortLinkPayload,
+  buildPathFromIds,
+  isRootItem,
 } from '@graasp/sdk';
 import { FAILURE_MESSAGES } from '@graasp/translations';
 
@@ -25,12 +27,7 @@ import { StatusCodes } from 'http-status-codes';
 import { v4 as uuidv4, v4 } from 'uuid';
 
 import { SETTINGS } from '../../src/config/constants';
-import {
-  getItemById,
-  isChild,
-  isRootItem,
-  transformIdForPath,
-} from '../../src/utils/item';
+import { getItemById } from '../../src/utils/item';
 import { getMemberById } from '../../src/utils/member';
 import {
   buildAppApiAccessTokenRoute,
@@ -262,7 +259,7 @@ export const mockPostItem = (
       return reply({
         ...body,
         id,
-        path: transformIdForPath(id),
+        path: buildPathFromIds(id),
         creator: CURRENT_USER.id,
       });
     },
@@ -437,7 +434,7 @@ export const mockGetChildren = ({
       const id = url.slice(API_HOST.length).split('/')[2];
       const item = getItemById(items, id);
 
-      const children = items.filter(isChild(id));
+      const children = items.filter((elem) => isRootItem(elem));
 
       if (item.public) {
         return reply(children);
@@ -506,7 +503,7 @@ export const mockMoveItems = (
       const updated = ids.map((id) => getItemById(items, id));
       // actually update cached items
       for (const item of updated) {
-        let path = transformIdForPath(item.id);
+        let path = buildPathFromIds(item.id);
         if (body.parentId) {
           const parentItem = getItemById(items, body.parentId);
           path = `${parentItem.path}.${path}`;
@@ -546,7 +543,7 @@ export const mockCopyItems = (
       for (const item of original) {
         const newId = uuidv4();
         // actually copy
-        let path = transformIdForPath(newId);
+        let path = buildPathFromIds(newId);
         if (body.parentId) {
           const parentItem = getItemById(items, body.parentId);
           path = `${parentItem.path}.${path}`;

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -1,3 +1,5 @@
+import { DiscriminatedItem } from '@graasp/sdk';
+
 import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 
 // use simple id format for tests
@@ -80,3 +82,10 @@ export const extractItemIdOrThrow = (
 
   return itemId;
 };
+
+export function getItemById<T extends DiscriminatedItem>(
+  items: T[],
+  id: string,
+): T | undefined {
+  return items.find(({ id: thisId }) => id === thisId);
+}

--- a/package.json
+++ b/package.json
@@ -88,13 +88,11 @@
     "prettier:write": "prettier --write {src,cypress}/**/*.{js,ts,tsx,json}",
     "type-check": "tsc --noEmit && tsc --noEmit -p cypress/tsconfig.json",
     "check": "yarn prettier:check && yarn lint && yarn type-check",
-    "hooks:uninstall": "husky uninstall",
-    "hooks:install": "husky install",
+    "postinstall": "husky install",
     "cypress:open": "env-cmd -f ./.env.test cypress open --browser chrome",
     "test": "yarn test:unit && yarn build:test && concurrently -k -s first \"yarn preview:test\" \"yarn cypress:run\"",
     "cypress:run": "env-cmd -f ./.env.test cypress run --browser chrome",
     "cypress:run:component": "env-cmd -f ./.env.test cypress run --component --browser chrome",
-    "postinstall": "husky install",
     "test:unit": "yarn vitest"
   },
   "browserslist": {

--- a/src/utils/item.test.ts
+++ b/src/utils/item.test.ts
@@ -6,7 +6,6 @@ import {
   getHighestPermissionForMemberFromMemberships,
   getParentsIdsFromPath,
   isUrlValid,
-  transformIdForPath,
 } from './item';
 
 describe('item utils', () => {
@@ -20,21 +19,6 @@ describe('item utils', () => {
     expect(isUrlValid('https://graasp.eu')).toBeTruthy();
     expect(isUrlValid('http://graasp.eu')).toBeTruthy();
     expect(isUrlValid('https://www.youtube.com/')).toBeTruthy();
-  });
-
-  it('transformIdForPath', () => {
-    expect(transformIdForPath('someid')).toEqual('someid');
-    expect(transformIdForPath('some-id')).toEqual('some_id');
-    const id = 'ecafbd2a-5688-11eb-ae93-0242ac130002';
-    const path = 'ecafbd2a_5688_11eb_ae93_0242ac130002';
-    expect(transformIdForPath(id)).toEqual(path);
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    expect(() => transformIdForPath(null)).toThrow();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    expect(() => transformIdForPath(undefined)).toThrow();
   });
 
   describe('getParentsIdsFromPath', () => {
@@ -66,7 +50,7 @@ describe('item utils', () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       expect(getParentsIdsFromPath(null)).toEqual([]);
-      expect(getParentsIdsFromPath(undefined)).toEqual([]);
+      expect(getParentsIdsFromPath()).toEqual([]);
     });
     it('ignoreSelf = true', () => {
       expect(getParentsIdsFromPath('someid', { ignoreSelf: true })).toEqual([]);

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -3,18 +3,11 @@ import { useEffect, useState } from 'react';
 
 import {
   DiscriminatedItem,
-  FolderItemExtra,
   ItemMembership,
   ItemType,
   getAppExtra,
   getLinkExtra,
 } from '@graasp/sdk';
-
-import { UUID_LENGTH } from '../config/constants';
-
-export const transformIdForPath = (id: string): string =>
-  // eslint-disable-next-line no-useless-escape
-  id.replace(/\-/g, '_');
 
 export const getParentsIdsFromPath = (
   path?: string,
@@ -40,14 +33,6 @@ export const getParentsIdsFromPath = (
   return ids;
 };
 
-export const buildPath = ({
-  prefix,
-  ids,
-}: {
-  prefix: string;
-  ids: string[];
-}): string => `${prefix}${ids.map((id) => transformIdForPath(id)).join('.')}`;
-
 export function getItemById<T extends DiscriminatedItem>(
   items: T[],
   id: string,
@@ -63,21 +48,6 @@ export const getDirectParentId = (path: string): string | null => {
   }
   return ids[parentIdx];
 };
-
-export const isChild = (
-  id: string,
-): (({ path }: { path: string }) => RegExpMatchArray | null) => {
-  const reg = new RegExp(`${transformIdForPath(id)}(?=\\.[^\\.]*$)`);
-  return ({ path }) => path.match(reg);
-};
-
-export const getChildren = (
-  items: DiscriminatedItem[],
-  id: string,
-): DiscriminatedItem[] => items.filter(isChild(id));
-
-export const isRootItem = ({ path }: { path: string }): boolean =>
-  path.length === UUID_LENGTH;
 
 export const isUrlValid = (str?: string | null): boolean => {
   if (!str) {
@@ -131,10 +101,6 @@ export const isItemValid = (item: Partial<DiscriminatedItem>): boolean => {
   return shouldHaveName && Boolean(hasValidTypeProperties);
 };
 
-export const getChildrenOrderFromFolderExtra = (
-  extra: FolderItemExtra,
-): string[] => extra[ItemType.FOLDER]?.childrenOrder ?? [];
-
 export const stripHtml = (str?: string | null): string =>
   str?.replace(/<[^>]*>?/gm, '') || '';
 
@@ -169,7 +135,7 @@ export function useIsParentInstance({
 
 // todo: to remove
 // get highest permission a member have over an item,
-// longer the itemPath, deeper is the permission, thus highested
+// longer the itemPath, deeper is the permission, thus highest
 export const getHighestPermissionForMemberFromMemberships = ({
   memberships,
   memberId,
@@ -192,6 +158,8 @@ export const getHighestPermissionForMemberFromMemberships = ({
   }
 
   const sorted = [...itemMemberships];
+
+  // sort memberships by the closest to you first (longest path)
   sorted?.sort((a, b) => (a.item.path.length > b.item.path.length ? -1 : 1));
 
   return sorted[0];

--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -33,13 +33,6 @@ export const getParentsIdsFromPath = (
   return ids;
 };
 
-export function getItemById<T extends DiscriminatedItem>(
-  items: T[],
-  id: string,
-): T | undefined {
-  return items.find(({ id: thisId }) => id === thisId);
-}
-
 export const getDirectParentId = (path: string): string | null => {
   const ids = getParentsIdsFromPath(path);
   const parentIdx = ids.length - 2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,10 +425,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.24.0":
-  version: 7.24.0
-  resolution: "@babel/helper-plugin-utils@npm:7.24.0"
-  checksum: 10/dc8c7af321baf7653d93315beffee1790eb2c464b4f529273a24c8743a3f3095bf3f2d11828cb2c52d56282ef43a4bdc67a79c9ab8dd845e35d01871f3f28a0e
+"@babel/helper-plugin-utils@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-plugin-utils@npm:7.22.5"
+  checksum: 10/ab220db218089a2aadd0582f5833fd17fa300245999f5f8784b10f5a75267c4e808592284a29438a0da365e702f05acb369f99e1c915c02f9f9210ec60eab8ea
   languageName: node
   linkType: hard
 
@@ -631,13 +631,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-jsx-self@npm:^7.18.6":
-  version: 7.24.1
-  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.24.1"
+  version: 7.23.3
+  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.23.3"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.24.0"
+    "@babel/helper-plugin-utils": "npm:^7.22.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/a0ff893b946bb0e501ad5aab43ce4b321ed9e74b94c0bc7191e2ee6409014fc96ee1a47dcb1ecdf445c44868564667ae16507ed4516dcacf6aa9c37a0ad28382
+  checksum: 10/882bf56bc932d015c2d83214133939ddcf342e5bcafa21f1a93b19f2e052145115e1e0351730897fd66e5f67cad7875b8a8d81ceb12b6e2a886ad0102cb4eb1f
   languageName: node
   linkType: hard
 
@@ -653,13 +653,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-jsx-source@npm:^7.19.6":
-  version: 7.24.1
-  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.24.1"
+  version: 7.23.3
+  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.23.3"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.24.0"
+    "@babel/helper-plugin-utils": "npm:^7.22.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/396ce878dc588e74113d38c5a1773e0850bb878a073238a74f8cdf62d968d56a644f5485bf4032dc095fe8863fe2bd9fbbbab6abc3adf69542e038ac5c689d4c
+  checksum: 10/92287fb797e522d99bdc77eaa573ce79ff0ad9f1cf4e7df374645e28e51dce0adad129f6f075430b129b5bac8dad843f65021970e12e992d6d6671f0d65bb1e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR:
- add unit tests with vitest
- remove unused utils functions and use functions from sdk
- fix a bug with the mock server for getting children