### PR TITLE
fix: display interpolation data on mouse hover for chatbox name

### DIFF
--- a/src/components/item/header/ItemHeaderActions.tsx
+++ b/src/components/item/header/ItemHeaderActions.tsx
@@ -67,7 +67,9 @@ const ItemHeaderActions = (): JSX.Element => {
           <ShareButton itemId={item.id} />
           <ChatboxButton
             showChat
-            tooltip={translateBuilder(BUILDER.ITEM_CHATBOX_TITLE)}
+            tooltip={translateBuilder(BUILDER.ITEM_CHATBOX_TITLE, {
+              name: item.name,
+            })}
             id={ITEM_CHATBOX_BUTTON_ID}
             onClick={onClickChatbox}
           />


### PR DESCRIPTION
in this PR fix an issue related to display interpolation data on mouse hover for chatbox name
#1141 