### PR TITLE
fix: allow capital letter in search, case insensitive search

### DIFF
--- a/src/components/item/ItemContent.tsx
+++ b/src/components/item/ItemContent.tsx
@@ -180,7 +180,9 @@ const FolderContent = ({
 
   // TODO: use hook's filter when available
   const folderChildren = children?.filter(
-    (f) => shouldDisplayItem(f.type) && f.name.includes(itemSearch.text),
+    (f) =>
+      shouldDisplayItem(f.type) &&
+      f.name.toLowerCase().includes(itemSearch.text.toLowerCase()),
   );
 
   if (isLoading) {

--- a/src/components/item/ItemSearch.tsx
+++ b/src/components/item/ItemSearch.tsx
@@ -2,7 +2,6 @@ import { ChangeEvent, useState } from 'react';
 
 import { Typography } from '@mui/material';
 
-import { DiscriminatedItem } from '@graasp/sdk';
 import { SearchInput } from '@graasp/ui';
 
 import { useBuilderTranslation } from '../../config/i18n';
@@ -32,7 +31,6 @@ export const useItemSearch = ({
 }: {
   onSearch?: () => void;
 } = {}): {
-  results?: DiscriminatedItem[];
   text: string;
   input: JSX.Element;
 } => {
@@ -41,7 +39,7 @@ export const useItemSearch = ({
 
   const handleSearchInput = (event: ChangeEvent<{ value: string }>) => {
     const text = event.target.value;
-    setSearchText(text.toLowerCase());
+    setSearchText(text);
     onSearch?.();
   };
 


### PR DESCRIPTION
Before this PR, the search in children does not allow to write capital letters, and the check is case sensitive, so it's impossible to find "Public" for example. 
So I lowercase both strings on check, and allow to write capital letters (that does not change anything, but at least it reflects the user input)
