### PR TITLE
fix: prevent modal calls on selection

### DIFF
--- a/src/components/item/FolderContent.tsx
+++ b/src/components/item/FolderContent.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Stack, Typography } from '@mui/material';
+import { Alert, Box, Stack, Typography, useTheme } from '@mui/material';
 
 import {
   PackedItem,
@@ -27,6 +27,7 @@ import {
   SelectionContextProvider,
   useSelectionContext,
 } from '../main/list/SelectionContext';
+import { useDragSelection } from '../main/list/useDragSelection';
 import { DesktopMap } from '../map/DesktopMap';
 import NoItemFilters from '../pages/NoItemFilters';
 import SortingSelect from '../table/SortingSelect';
@@ -49,6 +50,10 @@ const Content = ({ item, searchText, items, sortBy }: Props) => {
   const { itemTypes } = useFilterItemsContext();
   const { selectedIds, clearSelection, toggleSelection } =
     useSelectionContext();
+  const theme = useTheme();
+  const DragSelection = useDragSelection({
+    adjustments: { marginTop: 70, marginLeft: theme.spacing(3) },
+  });
 
   const enableEditing = item.permission
     ? PermissionLevelCompare.lte(PermissionLevel.Write, item.permission)
@@ -86,6 +91,7 @@ const Content = ({ item, searchText, items, sortBy }: Props) => {
             />
           </Stack>
         )}
+        <DragSelection />
       </>
     );
   }

--- a/src/components/item/FolderContent.tsx
+++ b/src/components/item/FolderContent.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Stack, Typography, useTheme } from '@mui/material';
+import { Alert, Box, Stack, Typography } from '@mui/material';
 
 import {
   PackedItem,
@@ -50,10 +50,7 @@ const Content = ({ item, searchText, items, sortBy }: Props) => {
   const { itemTypes } = useFilterItemsContext();
   const { selectedIds, clearSelection, toggleSelection } =
     useSelectionContext();
-  const theme = useTheme();
-  const DragSelection = useDragSelection({
-    adjustments: { marginTop: 70, marginLeft: theme.spacing(3) },
-  });
+  const DragSelection = useDragSelection();
 
   const enableEditing = item.permission
     ? PermissionLevelCompare.lte(PermissionLevel.Write, item.permission)
@@ -91,7 +88,7 @@ const Content = ({ item, searchText, items, sortBy }: Props) => {
             />
           </Stack>
         )}
-        <DragSelection />
+        {DragSelection}
       </>
     );
   }

--- a/src/components/item/copy/CopyModal.tsx
+++ b/src/components/item/copy/CopyModal.tsx
@@ -17,7 +17,7 @@ export const CopyModal = ({
   open: boolean;
   onClose: () => void;
   itemIds: DiscriminatedItem['id'][];
-}): JSX.Element => {
+}): JSX.Element | null => {
   const { mutate: copyItems } = mutations.useCopyItems();
   const { t: translateBuilder } = useBuilderTranslation();
 
@@ -35,6 +35,11 @@ export const CopyModal = ({
       translateKey: BUILDER.COPY_BUTTON,
       name,
     });
+
+  // prevent loading if not opened
+  if (!open) {
+    return null;
+  }
 
   return (
     <ItemSelectionModal

--- a/src/components/item/move/MoveModal.tsx
+++ b/src/components/item/move/MoveModal.tsx
@@ -65,6 +65,11 @@ export const MoveModal = ({
       name,
     });
 
+  // prevent loading if not opened
+  if (!open) {
+    return null;
+  }
+
   return items ? (
     <ItemSelectionModal
       titleKey={BUILDER.MOVE_ITEM_MODAL_TITLE}

--- a/src/components/main/list/SelectionContext.tsx
+++ b/src/components/main/list/SelectionContext.tsx
@@ -7,34 +7,24 @@ import {
   useState,
 } from 'react';
 
-import { PRIMARY_COLOR } from '@graasp/ui';
-
-import {
-  Box,
-  boxesIntersect,
-  useSelectionContainer,
-} from '@air/react-drag-to-select';
-
-import { ITEM_CARD_CLASS } from '@/config/selectors';
-
 type SelectionContextValue = {
   selectedIds: string[];
   toggleSelection: (id: string) => void;
+  addToSelection: (id: string) => void;
   clearSelection: () => void;
 };
 
 export const SelectionContext = createContext<SelectionContextValue>({
   selectedIds: [],
   toggleSelection: () => {},
+  addToSelection: () => {},
   clearSelection: () => {},
 });
 
 export const SelectionContextProvider = ({
   children,
-  elementClass = ITEM_CARD_CLASS,
 }: {
   children: JSX.Element;
-  elementClass?: string;
 }): JSX.Element => {
   const [selection, setSelection] = useState(new Set<string>());
   const elementsContainerRef = useRef<HTMLDivElement | null>(null);
@@ -55,58 +45,15 @@ export const SelectionContextProvider = ({
     [selection],
   );
 
-  const { DragSelection } = useSelectionContainer({
-    eventsElement: document.getElementById('root'),
-    onSelectionChange: (box) => {
-      /**
-       * Here we make sure to adjust the box's left and top with the scroll position of the window
-       * @see https://github.com/AirLabsTeam/react-drag-to-select/#scrolling
-       */
-      const scrollAwareBox: Box = {
-        ...box,
-        top: box.top + window.scrollY,
-        left: box.left + window.scrollX,
-      };
-
-      Array.from(document.getElementsByClassName(elementClass)).forEach(
-        (item) => {
-          const bb = item.getBoundingClientRect();
-          if (
-            boxesIntersect(scrollAwareBox, bb) &&
-            item.parentNode instanceof HTMLElement
-          ) {
-            const itemId = item.parentNode.dataset.id;
-            if (itemId) {
-              selection.add(itemId);
-            }
-          }
-        },
-      );
-
-      setSelection(new Set(selection));
-    },
-    shouldStartSelecting: (e) => {
-      // does not trigger drag selection if mousedown on card
-      if (e instanceof HTMLElement) {
-        return !e?.closest(`.${ITEM_CARD_CLASS}`);
+  const addToSelection = useCallback(
+    (id: string) => {
+      if (!selection.has(id)) {
+        selection.add(id);
+        setSelection(new Set(selection));
       }
-      return true;
     },
-    onSelectionStart: () => {
-      // clear selection on new dragging action
-      clearSelection();
-    },
-    onSelectionEnd: () => {},
-    selectionProps: {
-      style: {
-        border: `2px dashed ${PRIMARY_COLOR}`,
-        borderRadius: 4,
-        backgroundColor: 'lightblue',
-        opacity: 0.5,
-      },
-    },
-    isEnabled: true,
-  });
+    [selection],
+  );
 
   const value: SelectionContextValue = useMemo(
     () => ({
@@ -114,13 +61,19 @@ export const SelectionContextProvider = ({
       toggleSelection,
       clearSelection,
       elementsContainerRef,
+      addToSelection,
     }),
-    [selection, toggleSelection, clearSelection, elementsContainerRef],
+    [
+      selection,
+      toggleSelection,
+      clearSelection,
+      addToSelection,
+      elementsContainerRef,
+    ],
   );
 
   return (
     <SelectionContext.Provider value={value}>
-      <DragSelection />
       <div ref={elementsContainerRef}>{children}</div>
     </SelectionContext.Provider>
   );

--- a/src/components/main/list/useDragSelection.tsx
+++ b/src/components/main/list/useDragSelection.tsx
@@ -1,0 +1,77 @@
+import { ReactElement } from 'react';
+
+import { PRIMARY_COLOR } from '@graasp/ui';
+
+import {
+  Box,
+  boxesIntersect,
+  useSelectionContainer,
+} from '@air/react-drag-to-select';
+
+import { ITEM_CARD_CLASS } from '@/config/selectors';
+
+import { useSelectionContext } from './SelectionContext';
+
+export const useDragSelection = ({
+  elementClass = ITEM_CARD_CLASS,
+  adjustments = {},
+} = {}): (() => ReactElement) => {
+  const { addToSelection, clearSelection } = useSelectionContext();
+
+  const { DragSelection } = useSelectionContainer({
+    eventsElement: document.getElementById('root'),
+    onSelectionChange: (box) => {
+      /**
+       * Here we make sure to adjust the box's left and top with the scroll position of the window
+       * @see https://github.com/AirLabsTeam/react-drag-to-select/#scrolling
+       */
+      const scrollAwareBox: Box = {
+        ...box,
+        top: box.top + window.scrollY,
+        left: box.left + window.scrollX,
+      };
+
+      Array.from(document.getElementsByClassName(elementClass)).forEach(
+        (item) => {
+          const bb = item.getBoundingClientRect();
+          if (
+            boxesIntersect(scrollAwareBox, bb) &&
+            item.parentNode instanceof HTMLElement
+          ) {
+            const itemId = item.parentNode.dataset.id;
+            if (itemId) {
+              addToSelection(itemId);
+            }
+          }
+        },
+      );
+    },
+    shouldStartSelecting: (e) => {
+      // does not trigger drag selection if mousedown on card
+      if (e instanceof HTMLElement) {
+        return !e?.closest(`.${elementClass}`);
+      }
+      return true;
+    },
+    onSelectionStart: () => {
+      // clear selection on new dragging action
+      clearSelection();
+    },
+    onSelectionEnd: () => {},
+    selectionProps: {
+      style: {
+        // adjustement
+        // https://github.com/AirLabsTeam/react-drag-to-select/issues/30
+        ...adjustments,
+        border: `2px dashed ${PRIMARY_COLOR}`,
+        borderRadius: 4,
+        backgroundColor: 'lightblue',
+        opacity: 0.5,
+        zIndex: 999,
+      },
+    },
+    isEnabled: true,
+  });
+
+  return DragSelection;
+};

--- a/src/components/pages/RecycledItemsScreen.tsx
+++ b/src/components/pages/RecycledItemsScreen.tsx
@@ -1,4 +1,4 @@
-import { Alert, Stack, useTheme } from '@mui/material';
+import { Alert, Stack } from '@mui/material';
 
 import { Ordering } from '@/enums';
 
@@ -38,7 +38,6 @@ const RecycledItemsScreenContent = ({
   const { data: recycledItems, isLoading, isError } = hooks.useRecycledItems();
   const options = useTranslatedSortingOptions();
   const { shouldDisplayItem } = useFilterItemsContext();
-  const theme = useTheme();
   const { sortBy, setSortBy, ordering, setOrdering, sortFn } =
     useSorting<SortingOptions>({
       sortBy: SortingOptions.ItemUpdatedAt,
@@ -53,9 +52,7 @@ const RecycledItemsScreenContent = ({
     ?.sort(sortFn);
   const { selectedIds, toggleSelection } = useSelectionContext();
 
-  const DragSelection = useDragSelection({
-    adjustments: { marginTop: 70, marginLeft: theme.spacing(3) },
-  });
+  const DragSelection = useDragSelection();
 
   // render this when there is data from the query
   if (recycledItems?.length) {
@@ -121,7 +118,7 @@ const RecycledItemsScreenContent = ({
             )
           }
         </Stack>
-        <DragSelection />
+        {DragSelection}
       </>
     );
   }

--- a/src/components/pages/home/HomeScreen.tsx
+++ b/src/components/pages/home/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Alert, Box, LinearProgress, Stack } from '@mui/material';
+import { Alert, Box, LinearProgress, Stack, useTheme } from '@mui/material';
 
 import { Button } from '@graasp/ui';
 
@@ -9,6 +9,7 @@ import {
   SelectionContextProvider,
   useSelectionContext,
 } from '@/components/main/list/SelectionContext';
+import { useDragSelection } from '@/components/main/list/useDragSelection';
 import { ITEM_PAGE_SIZE } from '@/config/constants';
 import { ShowOnlyMeChangeType } from '@/config/types';
 import { ItemLayoutMode, Ordering } from '@/enums';
@@ -43,6 +44,7 @@ const HomeScreenContent = ({ searchText }: { searchText: string }) => {
   const { data: currentMember } = hooks.useCurrentMember();
   const { itemTypes } = useFilterItemsContext();
   const [showOnlyMe, setShowOnlyMe] = useState(false);
+  const theme = useTheme();
 
   const { selectedIds, toggleSelection, clearSelection } =
     useSelectionContext();
@@ -65,6 +67,10 @@ const HomeScreenContent = ({ searchText }: { searchText: string }) => {
       // todo: adapt page size given the user window height
       { pageSize: ITEM_PAGE_SIZE },
     );
+
+  const DragSelection = useDragSelection({
+    adjustments: { marginTop: 100, marginLeft: theme.spacing(3) },
+  });
 
   const onShowOnlyMeChange: ShowOnlyMeChangeType = (checked) => {
     setShowOnlyMe(checked);
@@ -129,6 +135,7 @@ const HomeScreenContent = ({ searchText }: { searchText: string }) => {
 
     return (
       <>
+        <DragSelection />
         <Stack
           alignItems="space-between"
           direction="column"

--- a/src/components/pages/home/HomeScreen.tsx
+++ b/src/components/pages/home/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Alert, Box, LinearProgress, Stack, useTheme } from '@mui/material';
+import { Alert, Box, LinearProgress, Stack } from '@mui/material';
 
 import { Button } from '@graasp/ui';
 
@@ -44,7 +44,6 @@ const HomeScreenContent = ({ searchText }: { searchText: string }) => {
   const { data: currentMember } = hooks.useCurrentMember();
   const { itemTypes } = useFilterItemsContext();
   const [showOnlyMe, setShowOnlyMe] = useState(false);
-  const theme = useTheme();
 
   const { selectedIds, toggleSelection, clearSelection } =
     useSelectionContext();
@@ -68,9 +67,7 @@ const HomeScreenContent = ({ searchText }: { searchText: string }) => {
       { pageSize: ITEM_PAGE_SIZE },
     );
 
-  const DragSelection = useDragSelection({
-    adjustments: { marginTop: 100, marginLeft: theme.spacing(3) },
-  });
+  const DragSelection = useDragSelection();
 
   const onShowOnlyMeChange: ShowOnlyMeChangeType = (checked) => {
     setShowOnlyMe(checked);
@@ -135,7 +132,7 @@ const HomeScreenContent = ({ searchText }: { searchText: string }) => {
 
     return (
       <>
-        <DragSelection />
+        {DragSelection}
         <Stack
           alignItems="space-between"
           direction="column"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,7 +11,6 @@ export const TREE_VIEW_MAX_WIDTH = 400;
 export const ITEM_SELECT_MODAL_TITLE_MAX_NAME_LENGTH = 15;
 export const UUID_LENGTH = 36;
 
-export const DRAWER_WIDTH = 240;
 export const DEFAULT_LOCALE = 'en-US';
 export const DEFAULT_EMAIL_FREQUENCY = 'always';
 


### PR DESCRIPTION
Selecting items trigger lots of renders.
- Moved down DragSelection (so some duplication happens). Some manual adjustement is necessary because of margin and padding.
-  do not fetch items for modal if they are not opened.