### PR TITLE
fix: does not trigger drag on mousedown svg

### DIFF
--- a/src/components/main/list/useDragSelection.tsx
+++ b/src/components/main/list/useDragSelection.tsx
@@ -53,7 +53,7 @@ export const useDragSelection = ({
     },
     shouldStartSelecting: (e) => {
       // does not trigger drag selection if mousedown on card
-      if (e instanceof HTMLElement) {
+      if (e instanceof HTMLElement || e instanceof SVGElement) {
         return !e?.closest(`.${elementClass}`);
       }
       return true;


### PR DESCRIPTION
Currently there's a small bug happening if you drag and you specifically click on an icon (svg), it will allow you to drag but then it will trigger the multi selection. 

This should fix the problem.