### PR TITLE
fix: fix edit modal content and navigation

### DIFF
--- a/cypress/e2e/item/edit/editFolder.cy.ts
+++ b/cypress/e2e/item/edit/editFolder.cy.ts
@@ -3,7 +3,10 @@ import { PackedFolderItemFactory } from '@graasp/sdk';
 import { HOME_PATH, buildItemPath } from '../../../../src/config/paths';
 import {
   EDIT_ITEM_BUTTON_CLASS,
+  EDIT_ITEM_MODAL_CANCEL_BUTTON_ID,
+  FOLDER_FORM_DESCRIPTION_ID,
   ITEM_FORM_CONFIRM_BUTTON_ID,
+  ITEM_FORM_NAME_INPUT_ID,
   buildItemsGridMoreButtonSelector,
 } from '../../../../src/config/selectors';
 import { EDIT_ITEM_PAUSE } from '../../../support/constants';
@@ -92,6 +95,32 @@ describe('Edit Folder', () => {
         expect(name).to.equal(EDITED_FIELDS.name);
         cy.get('@getItem').its('response.url').should('contain', itemToEdit.id);
       },
+    );
+  });
+
+  // moving from parent to child might not update info since the item folder component is the same
+  it.only('edit 2 folders should display the correct data', () => {
+    const parentItem = PackedFolderItemFactory();
+    const itemToEdit = PackedFolderItemFactory({
+      parentItem,
+      description: 'first description',
+    });
+    cy.setUpApi({ items: [parentItem, itemToEdit] });
+    // go to children item
+    cy.visit(buildItemPath(parentItem.id));
+
+    // open edit
+    cy.get(`.${EDIT_ITEM_BUTTON_CLASS}`).click();
+    cy.get(`#${EDIT_ITEM_MODAL_CANCEL_BUTTON_ID}`).click();
+
+    // go to child
+    cy.goToItemInCard(itemToEdit.id);
+
+    cy.get(`.${EDIT_ITEM_BUTTON_CLASS}`).click();
+    cy.get(`#${ITEM_FORM_NAME_INPUT_ID}`).should('have.value', itemToEdit.name);
+    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID} p`).should(
+      'contain',
+      itemToEdit.description,
     );
   });
 });

--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -1012,15 +1012,8 @@ export const mockGetItemLoginSchemaType = (items: ItemForTest[]): void => {
       const itemId = url.slice(API_HOST.length).split('/')[2];
       const item = items.find(({ id }) => itemId === id);
 
-      const type = item?.itemLoginSchema?.type;
-      if (!type) {
-        return reply({
-          statusCode: StatusCodes.NOT_FOUND,
-        });
-      }
-
       return reply({
-        body: type,
+        body: item?.itemLoginSchema?.type ?? null,
         statusCode: StatusCodes.OK,
       });
     },

--- a/src/components/item/edit/EditModal.tsx
+++ b/src/components/item/edit/EditModal.tsx
@@ -1,4 +1,4 @@
-import { ComponentType as CT, useState } from 'react';
+import { ComponentType as CT, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import {
@@ -56,6 +56,12 @@ const EditModal = ({ item, onClose, open }: Props): JSX.Element => {
   // updated properties are separated from the original item
   // so only necessary properties are sent when editing
   const [updatedItem, setUpdatedItem] = useState<DiscriminatedItem>(item);
+
+  useEffect(() => {
+    if (item.id !== updatedItem.id) {
+      setUpdatedItem(item);
+    }
+  }, [item, updatedItem.id]);
 
   const ComponentType = ((): EditModalContentType => {
     switch (item.type) {

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -31,14 +31,11 @@ const Navigator = (): JSX.Element | null => {
   const { pathname } = useLocation();
   const { data: currentMember } = useCurrentMember();
   const { data: item, isLoading: isItemLoading } = useItem(itemId);
-  const itemPath = item?.path;
 
   const { pathname: location } = useLocation();
 
   const { data: parents, isLoading: areParentsLoading } = useParents({
     id: itemId,
-    path: itemPath,
-    enabled: !!itemPath,
   });
 
   if (isItemLoading || areParentsLoading) {

--- a/src/components/pages/item/ItemScreen.tsx
+++ b/src/components/pages/item/ItemScreen.tsx
@@ -7,7 +7,6 @@ import { OutletType } from './type';
 
 const ItemPage = (): JSX.Element => {
   const { item } = useOutletContext<OutletType>();
-
   return (
     <ItemMain item={item}>
       <ItemContent />


### PR DESCRIPTION
This PR fixes two problems:

- navigating from item root to child was not updating the parent. We removed the opti `path` that was unsync with `itemId`
- we fixed the edit item modal content, by adding a `useEffect`. This is just some tape on the problem for now, we should refactor the full component. #1498   