### PR TITLE
refactor: refactor edit base item form

### DIFF
--- a/cypress/e2e/item/settings/itemSettings.cy.ts
+++ b/cypress/e2e/item/settings/itemSettings.cy.ts
@@ -1,5 +1,4 @@
 import {
-  DescriptionPlacement,
   ItemType,
   MaxWidth,
   MimeTypes,
@@ -25,14 +24,12 @@ import {
   ITEM_MAIN_CLASS,
   ITEM_PANEL_NAME_ID,
   ITEM_PANEL_TABLE_ID,
-  ITEM_SETTING_DESCRIPTION_PLACEMENT_SELECT_ID,
   LANGUAGE_SELECTOR_ID,
   SETTINGS_CHATBOX_TOGGLE_ID,
   SETTINGS_LINK_SHOW_BUTTON_ID,
   SETTINGS_LINK_SHOW_IFRAME_ID,
   SETTINGS_PINNED_TOGGLE_ID,
   SETTINGS_SAVE_ACTIONS_TOGGLE_ID,
-  buildDescriptionPlacementId,
   buildItemsGridMoreButtonSelector,
   buildSettingsButtonId,
 } from '../../../../src/config/selectors';
@@ -444,42 +441,6 @@ describe('Item Settings', () => {
           'have.value',
           FILE.settings.maxWidth,
         );
-      });
-    });
-
-    describe('DescriptionPlacement Settings', () => {
-      it('folder should not have description placement', () => {
-        const FOLDER = PackedFolderItemFactory();
-        cy.setUpApi({ items: [FOLDER] });
-        const { id, type } = FOLDER;
-
-        cy.visit(buildItemSettingsPath(id));
-
-        cy.get(`#${ITEM_PANEL_TABLE_ID}`).contains(type);
-
-        cy.get(`#${ITEM_SETTING_DESCRIPTION_PLACEMENT_SELECT_ID}`).should(
-          'not.exist',
-        );
-      });
-
-      it('update placement to above for file', () => {
-        const LINK = PackedLinkItemFactory();
-        cy.setUpApi({ items: [LINK] });
-        const { id } = LINK;
-
-        cy.visit(buildItemSettingsPath(id));
-
-        cy.get(`#${ITEM_SETTING_DESCRIPTION_PLACEMENT_SELECT_ID}`).click();
-        cy.get(
-          `#${buildDescriptionPlacementId(DescriptionPlacement.ABOVE)}`,
-        ).click();
-
-        cy.wait(`@editItem`).then(({ request: { url, body } }) => {
-          expect(url).to.contain(id);
-          expect(body?.settings).to.contain({
-            descriptionPlacement: DescriptionPlacement.ABOVE,
-          });
-        });
       });
     });
   });

--- a/src/components/item/form/BaseItemForm.tsx
+++ b/src/components/item/form/BaseItemForm.tsx
@@ -1,10 +1,10 @@
 import { FormProvider, useForm } from 'react-hook-form';
 
+import { LoadingButton } from '@mui/lab';
 import { Box, DialogActions, DialogContent } from '@mui/material';
 
 import { DescriptionPlacementType, DiscriminatedItem } from '@graasp/sdk';
 import { COMMON } from '@graasp/translations';
-import { Button } from '@graasp/ui';
 
 import CancelButton from '@/components/common/CancelButton';
 import { useCommonTranslation } from '@/config/i18n';
@@ -32,7 +32,7 @@ const BaseItemForm = ({
 }): JSX.Element => {
   const { t: translateCommon } = useCommonTranslation();
   const methods = useForm<Inputs>({ defaultValues: { name: item.name } });
-  const { mutateAsync: editItem } = mutations.useEditItem();
+  const { mutateAsync: editItem, isPending } = mutations.useEditItem();
   const {
     setValue,
     handleSubmit,
@@ -54,27 +54,31 @@ const BaseItemForm = ({
   }
   return (
     <Box component="form" onSubmit={handleSubmit(onSubmit)}>
-      <DialogContent>
-        <FormProvider {...methods}>
+      <FormProvider {...methods}>
+        <DialogContent>
           <ItemNameField required />
-
           <DescriptionAndPlacementForm
             onDescriptionChange={(newValue) => {
               setValue('description', newValue);
             }}
           />
-        </FormProvider>
-      </DialogContent>
-      <DialogActions>
-        <CancelButton id={EDIT_ITEM_MODAL_CANCEL_BUTTON_ID} onClick={onClose} />
-        <Button
-          id={ITEM_FORM_CONFIRM_BUTTON_ID}
-          type="submit"
-          disabled={!isValid}
-        >
-          {translateCommon(COMMON.SAVE_BUTTON)}
-        </Button>
-      </DialogActions>
+        </DialogContent>
+        <DialogActions>
+          <CancelButton
+            id={EDIT_ITEM_MODAL_CANCEL_BUTTON_ID}
+            onClick={onClose}
+          />
+          <LoadingButton
+            loading={isPending}
+            id={ITEM_FORM_CONFIRM_BUTTON_ID}
+            type="submit"
+            disabled={!isValid}
+            variant="contained"
+          >
+            {translateCommon(COMMON.SAVE_BUTTON)}
+          </LoadingButton>
+        </DialogActions>
+      </FormProvider>
     </Box>
   );
 };

--- a/src/components/item/form/description/DescriptionAndPlacementForm.tsx
+++ b/src/components/item/form/description/DescriptionAndPlacementForm.tsx
@@ -1,23 +1,17 @@
 import { Stack } from '@mui/material';
 
-import { DescriptionPlacementType } from '@graasp/sdk';
-
 import { DescriptionForm, type DescriptionFormProps } from './DescriptionForm';
 import DescriptionPlacementForm from './DescriptionPlacementForm';
 
 type DescriptionAndPlacementFormProps = {
   id?: string;
   description?: string;
-  descriptionPlacement?: DescriptionPlacementType;
-  onPlacementChange: (v: DescriptionPlacementType) => void;
   onDescriptionChange: DescriptionFormProps['onChange'];
 };
 
 export const DescriptionAndPlacementForm = ({
   id,
   description = '',
-  descriptionPlacement,
-  onPlacementChange,
   onDescriptionChange,
 }: DescriptionAndPlacementFormProps): JSX.Element => (
   <Stack spacing={2}>
@@ -26,9 +20,6 @@ export const DescriptionAndPlacementForm = ({
       value={description}
       onChange={onDescriptionChange}
     />
-    <DescriptionPlacementForm
-      descriptionPlacement={descriptionPlacement}
-      onPlacementChange={onPlacementChange}
-    />
+    <DescriptionPlacementForm />
   </Stack>
 );

--- a/src/components/item/form/description/DescriptionPlacementForm.tsx
+++ b/src/components/item/form/description/DescriptionPlacementForm.tsx
@@ -1,3 +1,5 @@
+import { Controller, useFormContext } from 'react-hook-form';
+
 import { MenuItem, Select } from '@mui/material';
 
 import { DescriptionPlacement, DescriptionPlacementType } from '@graasp/sdk';
@@ -13,22 +15,14 @@ import { BUILDER } from '@/langs/constants';
 
 import ItemSettingProperty from '../../settings/ItemSettingProperty';
 
-const DEFAULT_PLACEMENT = DescriptionPlacement.BELOW;
-
-type DescriptionPlacementFormProps = {
-  onPlacementChange: (payload: DescriptionPlacementType) => void;
-  descriptionPlacement?: DescriptionPlacementType;
-};
-
-const DescriptionPlacementForm = ({
-  onPlacementChange,
-  descriptionPlacement = DEFAULT_PLACEMENT,
-}: DescriptionPlacementFormProps): JSX.Element | null => {
+const DescriptionPlacementForm = (): JSX.Element | null => {
   const { t } = useBuilderTranslation();
+  const { watch, control } = useFormContext<{
+    descriptionPlacement: DescriptionPlacementType;
+  }>();
 
-  const handlePlacementChanged = (placement: string): void => {
-    onPlacementChange(placement as DescriptionPlacementType);
-  };
+  const descriptionPlacement = watch('descriptionPlacement');
+
   return (
     <ItemSettingProperty
       title={t(BUILDER.ITEM_SETTINGS_DESCRIPTION_PLACEMENT_TITLE)}
@@ -43,21 +37,29 @@ const DescriptionPlacementForm = ({
         placement: t(descriptionPlacement).toLowerCase(),
       })}
       inputSetting={
-        <Select
-          id={ITEM_SETTING_DESCRIPTION_PLACEMENT_SELECT_ID}
-          value={descriptionPlacement}
-          onChange={(e) => handlePlacementChanged(e.target.value)}
-          size="small"
-        >
-          {Object.values(DescriptionPlacement).map((placement) => (
-            <MenuItem
-              id={buildDescriptionPlacementId(placement)}
-              value={placement}
+        <Controller
+          name="descriptionPlacement"
+          control={control}
+          render={({ field }) => (
+            <Select
+              id={ITEM_SETTING_DESCRIPTION_PLACEMENT_SELECT_ID}
+              value={field.value ?? DescriptionPlacement.BELOW}
+              onChange={(v) => {
+                field.onChange(v);
+              }}
+              size="small"
             >
-              {t(placement)}
-            </MenuItem>
-          ))}
-        </Select>
+              {Object.values(DescriptionPlacement).map((placement) => (
+                <MenuItem
+                  id={buildDescriptionPlacementId(placement)}
+                  value={placement}
+                >
+                  {t(placement)}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
       }
     />
   );

--- a/src/components/item/form/file/FileForm.tsx
+++ b/src/components/item/form/file/FileForm.tsx
@@ -131,16 +131,10 @@ const FileForm = ({
             />
           )}
           <DescriptionAndPlacementForm
-            onPlacementChange={(newValue) =>
-              setValue('descriptionPlacement', newValue)
-            }
             onDescriptionChange={(newValue) => {
               setValue('description', newValue);
             }}
             description={description ?? item?.description ?? ''}
-            descriptionPlacement={
-              descriptionPlacement ?? item?.settings?.descriptionPlacement
-            }
           />
         </DialogContent>
         <DialogActions>

--- a/src/components/item/settings/ItemSettingsProperties.tsx
+++ b/src/components/item/settings/ItemSettingsProperties.tsx
@@ -20,7 +20,6 @@ import {
 } from '@/config/selectors';
 import { BUILDER } from '@/langs/constants';
 
-import DescriptionPlacementForm from '../form/description/DescriptionPlacementForm';
 import HideSettingCheckbox from '../sharing/HideSettingCheckbox';
 import ItemSettingCheckBoxProperty from './ItemSettingCheckBoxProperty';
 import LinkSettings from './LinkSettings';
@@ -177,15 +176,6 @@ const ItemSettingsProperties = ({ item }: Props): JSX.Element => {
       />
 
       {renderSettingsPerType()}
-
-      {item.type !== ItemType.FOLDER && (
-        <DescriptionPlacementForm
-          onPlacementChange={(newPlacement) =>
-            handleSettingChanged('descriptionPlacement', newPlacement)
-          }
-          descriptionPlacement={item.settings.descriptionPlacement}
-        />
-      )}
     </Stack>
   );
 };


### PR DESCRIPTION
I updated the base item form (edit modal for link, app, etherpad and h5p).
I removed the description placement in the settings page, it was not matching well with my refactor, and it didn't make much sense to have it in the settings. We can discuss it. 

ref #1551 