### PR TITLE
fix: link crash when url is not valid

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,4 @@
-import setupCoverage from '@cypress/code-coverage/task';
+import setupCoverage from '@cypress/code-coverage/task.js';
 import { defineConfig } from 'cypress';
 
 const ENV = {

--- a/src/components/item/form/link/LinkForm.tsx
+++ b/src/components/item/form/link/LinkForm.tsx
@@ -149,7 +149,7 @@ export const LinkForm = ({
         item={{
           type: ItemType.LINK,
           settings: {},
-          extra: { [ItemType.LINK]: { url } },
+          extra: { [ItemType.LINK]: { url: normalizeURL(url) } },
         }}
         showIframe
         showButton={false}


### PR DESCRIPTION
fix #1590 